### PR TITLE
expose getter for `limits` on `AuthorizationBuilder`

### DIFF
--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let mut authorizer = AuthorizerBuilder::new()
         .allow_all()
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
@@ -50,7 +50,7 @@ fn main() {
 
     let mut authorizer = AuthorizerBuilder::new()
         .allow_all()
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -1199,7 +1199,7 @@ mod tests {
                 scope_params,
             )
             .unwrap()
-            .limits(AuthorizerLimits {
+            .set_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10), //Set 10 seconds as the maximum time allowed for the authorization due to "cheap" worker on GitHub Actions
                 ..Default::default()
             })

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -325,7 +325,7 @@ mod tests {
         let secp_pubkey = KeyPair::new_with_algorithm(Algorithm::Secp256r1).public();
         let ed_pubkey = KeyPair::new_with_algorithm(Algorithm::Ed25519).public();
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),
@@ -357,7 +357,7 @@ mod tests {
         let secp_pubkey = KeyPair::new_with_algorithm(Algorithm::Secp256r1).public();
         let ed_pubkey = KeyPair::new_with_algorithm(Algorithm::Ed25519).public();
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),
@@ -415,7 +415,7 @@ mod tests {
     #[test]
     fn roundtrip_without_token() {
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),
@@ -449,7 +449,7 @@ mod tests {
     #[test]
     fn roundtrip_with_eval_error() {
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -237,9 +237,13 @@ impl AuthorizerBuilder {
     /// Sets the runtime limits of the authorizer
     ///
     /// Those limits cover all the executions under the `authorize`, `query` and `query_all` methods
-    pub fn limits(mut self, limits: AuthorizerLimits) -> Self {
+    pub fn set_limits(mut self, limits: AuthorizerLimits) -> Self {
         self.limits = limits;
         self
+    }
+
+    pub fn limits(&self) -> &AuthorizerLimits {
+        &self.limits
     }
 
     /// Replaces the registered external functions

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -1384,7 +1384,7 @@ mod tests {
             .check("check if bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
             .unwrap()
             .allow_all()
-            .limits(AuthorizerLimits {
+            .set_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             })

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -76,7 +76,7 @@ fn authorizer_macro() {
     );
 
     let mut authorizer = b
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
@@ -102,7 +102,7 @@ allow if true;
 #[test]
 fn authorizer_macro_trailing_comma() {
     let a = authorizer!(r#"fact("test", {my_key});"#, my_key = "my_value",)
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
@@ -272,7 +272,7 @@ fn json() {
           $value.get("id") == $id,
           $value.get("roles").contains("admin");"#
     )
-    .limits(RunLimits {
+    .set_limits(RunLimits {
         max_time: Duration::from_secs(10),
         ..Default::default()
     })


### PR DESCRIPTION
The `limits` field used to be available on `Authorizer`, and is not visible in the builder