### PR TITLE
Missing bits of AuthorizerBuilder

### DIFF
--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let mut authorizer = AuthorizerBuilder::new()
         .allow_all()
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
@@ -50,7 +50,7 @@ fn main() {
 
     let mut authorizer = AuthorizerBuilder::new()
         .allow_all()
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -1199,7 +1199,7 @@ mod tests {
                 scope_params,
             )
             .unwrap()
-            .limits(AuthorizerLimits {
+            .set_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10), //Set 10 seconds as the maximum time allowed for the authorization due to "cheap" worker on GitHub Actions
                 ..Default::default()
             })

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -325,7 +325,7 @@ mod tests {
         let secp_pubkey = KeyPair::new_with_algorithm(Algorithm::Secp256r1).public();
         let ed_pubkey = KeyPair::new_with_algorithm(Algorithm::Ed25519).public();
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),
@@ -357,7 +357,7 @@ mod tests {
         let secp_pubkey = KeyPair::new_with_algorithm(Algorithm::Secp256r1).public();
         let ed_pubkey = KeyPair::new_with_algorithm(Algorithm::Ed25519).public();
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),
@@ -415,7 +415,7 @@ mod tests {
     #[test]
     fn roundtrip_without_token() {
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),
@@ -449,7 +449,7 @@ mod tests {
     #[test]
     fn roundtrip_with_eval_error() {
         let builder = AuthorizerBuilder::new()
-            .limits(RunLimits {
+            .set_limits(RunLimits {
                 max_facts: 42,
                 max_iterations: 42,
                 max_time: Duration::from_secs(1),

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -237,9 +237,13 @@ impl AuthorizerBuilder {
     /// Sets the runtime limits of the authorizer
     ///
     /// Those limits cover all the executions under the `authorize`, `query` and `query_all` methods
-    pub fn limits(mut self, limits: AuthorizerLimits) -> Self {
+    pub fn set_limits(mut self, limits: AuthorizerLimits) -> Self {
         self.limits = limits;
         self
+    }
+
+    pub fn limits(&self) -> &AuthorizerLimits {
+        &self.limits
     }
 
     /// Replaces the registered external functions

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -39,6 +39,26 @@ impl AuthorizerBuilder {
         AuthorizerBuilder::default()
     }
 
+    /// merge datalog contents (facts, rules, checks) from a `BlockBuilder` into
+    pub fn merge_block(mut self, other: BlockBuilder) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.merge(other);
+        self
+    }
+
+    /// merge datalog contents (facts, rules, checks, policies) from another `AuthorizerBuilder` into `self`, as well as registered extern functions.
+    ///
+    /// If a registered extern function is defined on both sides, the one from `self` is kept.
+    ///
+    /// `AuthorizerLimits` from `self` are kept, those from `other` are discarded
+    pub fn merge(mut self, mut other: AuthorizerBuilder) -> Self {
+        self.policies.append(&mut other.policies);
+        self.extern_funcs.extend(other.extern_funcs);
+        self.authorizer_block_builder = self
+            .authorizer_block_builder
+            .merge(other.authorizer_block_builder);
+        self
+    }
+
     pub fn fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     convert::TryInto,
-    fmt::Write,
+    fmt::{self, Write},
     time::{Duration, SystemTime},
 };
 
@@ -405,6 +405,18 @@ impl AuthorizerBuilder {
             limits: self.limits,
             execution_time: None,
         })
+    }
+}
+
+impl fmt::Display for AuthorizerBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.authorizer_block_builder.fmt(f)?;
+        for mut policy in self.policies.clone().into_iter() {
+            policy.apply_parameters();
+            writeln!(f, "{policy};")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/biscuit-auth/src/token/builder/policy.rs
+++ b/biscuit-auth/src/token/builder/policy.rs
@@ -105,6 +105,12 @@ impl Policy {
 
         Ok(())
     }
+
+    pub fn apply_parameters(&mut self) {
+        for rule in self.queries.iter_mut() {
+            rule.apply_parameters();
+        }
+    }
 }
 
 impl fmt::Display for Policy {

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -1384,7 +1384,7 @@ mod tests {
             .check("check if bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
             .unwrap()
             .allow_all()
-            .limits(AuthorizerLimits {
+            .set_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             })

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -76,7 +76,7 @@ fn authorizer_macro() {
     );
 
     let mut authorizer = b
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
@@ -102,7 +102,7 @@ allow if true;
 #[test]
 fn authorizer_macro_trailing_comma() {
     let a = authorizer!(r#"fact("test", {my_key});"#, my_key = "my_value",)
-        .limits(RunLimits {
+        .set_limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
@@ -272,7 +272,7 @@ fn json() {
           $value.get("id") == $id,
           $value.get("roles").contains("admin");"#
     )
-    .limits(RunLimits {
+    .set_limits(RunLimits {
         max_time: Duration::from_secs(10),
         ..Default::default()
     })


### PR DESCRIPTION
This is was not implemented when AuthorizerBuilder was extracted from Authorizer:

- `impl Display for AuthorizerBuilder`
- `limits()` to retreive current limits
- `merge()` and `merge_block()`