### PR TITLE
doc: fix cargo doc warnings

### DIFF
--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -20,7 +20,7 @@ mod snapshot;
 
 /// used to check authorization policies on a token
 ///
-/// can be created from [Biscuit::authorizer] or [Authorizer::new]
+/// can be created from [AuthorizerBuilder::build], [AuthorizerBuilder::build_unauthenticated] or [Biscuit::authorizer]
 #[derive(Clone, Debug)]
 pub struct Authorizer {
     pub(crate) authorizer_block_builder: BlockBuilder,

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -159,6 +159,8 @@ impl Biscuit {
     }
 
     /// creates an authorizer from this token
+    ///
+    /// Such an authorizer can only be used for querying, since it will contain no authorization policy.
     pub fn authorizer(&self) -> Result<Authorizer, error::Token> {
         Authorizer::from_token(self)
     }

--- a/biscuit-parser/src/parser.rs
+++ b/biscuit-parser/src/parser.rs
@@ -483,9 +483,9 @@ fn fold_exprs(initial: Expr, remainder: Vec<(builder::Binary, Expr)>) -> Expr {
 }
 
 /// Top-lever parser for an expression. Expression parsers are layered in
-/// order to support operator precedence (see https://en.wikipedia.org/wiki/Operator-precedence_parser).
+/// order to support operator precedence (see <https://en.wikipedia.org/wiki/Operator-precedence_parser>).
 ///
-/// See https://github.com/biscuit-auth/biscuit/blob/master/SPECIFICATIONS.md#grammar
+/// See <https://github.com/biscuit-auth/biscuit/blob/master/SPECIFICATIONS.md#grammar>
 /// for the precedence order of operators in biscuit datalog.
 ///
 /// The operators with the lowest precedence are parsed at the outer level,


### PR DESCRIPTION
we should improve `Biscuit::authorizer()`’s doc to make it clear that it is only useful now for querying and that the old way of using `Biscuit::authorizer()` and then mutating the authorizer is now done differently.