### PR TITLE
clean up the Protobuf definitions

### DIFF
--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -9,7 +9,7 @@ extern crate biscuit_auth as biscuit;
 use biscuit::builder::BlockBuilder;
 use biscuit::datalog::SymbolTable;
 use biscuit::error;
-use biscuit::format::convert::v2 as convert;
+use biscuit::format::convert;
 use biscuit::macros::*;
 use biscuit::{builder::*, builder_ext::*, Biscuit};
 use biscuit::{KeyPair, PrivateKey, PublicKey};

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -390,7 +390,7 @@ fn validate_token_with_limits_and_external_functions(
     let mut authorizer_checks = Vec::new();
     for (i, block) in snapshot.world.blocks.iter().enumerate() {
         let mut rules: Vec<String> = Vec::new();
-        for rule in block.rules_v2.iter() {
+        for rule in block.rules.iter() {
             let r =
                 convert::proto_rule_to_token_rule(&rule, snapshot.world.version.unwrap()).unwrap();
             rules.push(symbols.print_rule(&r.0));
@@ -404,7 +404,7 @@ fn validate_token_with_limits_and_external_functions(
         }
 
         let mut checks = Vec::new();
-        for check in block.checks_v2.iter() {
+        for check in block.checks.iter() {
             let c = convert::proto_check_to_token_check(&check, snapshot.world.version.unwrap())
                 .unwrap();
             checks.push(symbols.print_check(&c));
@@ -419,7 +419,7 @@ fn validate_token_with_limits_and_external_functions(
     }
 
     let mut rules: Vec<String> = Vec::new();
-    for rule in snapshot.world.authorizer_block.rules_v2 {
+    for rule in snapshot.world.authorizer_block.rules {
         let r = convert::proto_rule_to_token_rule(&rule, snapshot.world.version.unwrap()).unwrap();
 
         rules.push(symbols.print_rule(&r.0));
@@ -433,7 +433,7 @@ fn validate_token_with_limits_and_external_functions(
     }
 
     let mut checks = Vec::new();
-    for check in snapshot.world.authorizer_block.checks_v2 {
+    for check in snapshot.world.authorizer_block.checks {
         let c =
             convert::proto_check_to_token_check(&check, snapshot.world.version.unwrap()).unwrap();
         checks.push(symbols.print_check(&c));

--- a/biscuit-auth/src/format/convert.rs
+++ b/biscuit-auth/src/format/convert.rs
@@ -4,42 +4,37 @@
  */
 //! helper functions for conversion between internal structures and Protobuf
 
-use self::v2::proto_scope_to_token_scope;
-
 use super::schema;
 use crate::builder::Convert;
 use crate::crypto::PublicKey;
 use crate::datalog::*;
 use crate::error;
+use crate::format::schema::Empty;
+use crate::format::schema::MapEntry;
 use crate::token::public_keys::PublicKeys;
 use crate::token::Scope;
 use crate::token::{authorizer::AuthorizerPolicies, Block};
 use crate::token::{DATALOG_3_1, DATALOG_3_2, DATALOG_3_3, MAX_SCHEMA_VERSION, MIN_SCHEMA_VERSION};
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 pub fn token_block_to_proto_block(input: &Block) -> schema::Block {
     schema::Block {
         symbols: input.symbols.strings(),
         context: input.context.clone(),
         version: Some(input.version),
-        facts: input
-            .facts
-            .iter()
-            .map(v2::token_fact_to_proto_fact)
-            .collect(),
-        rules: input
-            .rules
-            .iter()
-            .map(v2::token_rule_to_proto_rule)
-            .collect(),
+        facts: input.facts.iter().map(token_fact_to_proto_fact).collect(),
+        rules: input.rules.iter().map(token_rule_to_proto_rule).collect(),
         checks: input
             .checks
             .iter()
-            .map(v2::token_check_to_proto_check)
+            .map(token_check_to_proto_check)
             .collect(),
         scope: input
             .scopes
             .iter()
-            .map(v2::token_scope_to_proto_scope)
+            .map(token_scope_to_proto_scope)
             .collect(),
         public_keys: input
             .public_keys
@@ -68,11 +63,11 @@ pub fn proto_block_to_token_block(
     let mut checks = vec![];
     let mut scopes = vec![];
     for fact in input.facts.iter() {
-        facts.push(v2::proto_fact_to_token_fact(fact)?);
+        facts.push(proto_fact_to_token_fact(fact)?);
     }
 
     for rule in input.rules.iter() {
-        rules.push(v2::proto_rule_to_token_rule(rule, version)?.0);
+        rules.push(proto_rule_to_token_rule(rule, version)?.0);
     }
 
     if version < MAX_SCHEMA_VERSION {
@@ -99,10 +94,10 @@ pub fn proto_block_to_token_block(
     }
 
     for check in input.checks.iter() {
-        checks.push(v2::proto_check_to_token_check(check, version)?);
+        checks.push(proto_check_to_token_check(check, version)?);
     }
     for scope in input.scope.iter() {
-        scopes.push(v2::proto_scope_to_token_scope(scope)?);
+        scopes.push(proto_scope_to_token_scope(scope)?);
     }
 
     let context = input.context.clone();
@@ -138,25 +133,17 @@ pub fn token_block_to_proto_snapshot_block(input: &Block) -> schema::SnapshotBlo
     schema::SnapshotBlock {
         context: input.context.clone(),
         version: Some(input.version),
-        facts: input
-            .facts
-            .iter()
-            .map(v2::token_fact_to_proto_fact)
-            .collect(),
-        rules: input
-            .rules
-            .iter()
-            .map(v2::token_rule_to_proto_rule)
-            .collect(),
+        facts: input.facts.iter().map(token_fact_to_proto_fact).collect(),
+        rules: input.rules.iter().map(token_rule_to_proto_rule).collect(),
         checks: input
             .checks
             .iter()
-            .map(v2::token_check_to_proto_check)
+            .map(token_check_to_proto_check)
             .collect(),
         scope: input
             .scopes
             .iter()
-            .map(v2::token_scope_to_proto_scope)
+            .map(token_scope_to_proto_scope)
             .collect(),
         external_key: input.external_key.map(|key| key.to_proto()),
     }
@@ -179,11 +166,11 @@ pub fn proto_snapshot_block_to_token_block(
     let mut checks = vec![];
     let mut scopes = vec![];
     for fact in input.facts.iter() {
-        facts.push(v2::proto_fact_to_token_fact(fact)?);
+        facts.push(proto_fact_to_token_fact(fact)?);
     }
 
     for rule in input.rules.iter() {
-        rules.push(v2::proto_rule_to_token_rule(rule, version)?.0);
+        rules.push(proto_rule_to_token_rule(rule, version)?.0);
     }
 
     if version == MIN_SCHEMA_VERSION && input.checks.iter().any(|c| c.kind.is_some()) {
@@ -193,10 +180,10 @@ pub fn proto_snapshot_block_to_token_block(
     }
 
     for check in input.checks.iter() {
-        checks.push(v2::proto_check_to_token_check(check, version)?);
+        checks.push(proto_check_to_token_check(check, version)?);
     }
     for scope in input.scope.iter() {
-        scopes.push(v2::proto_scope_to_token_scope(scope)?);
+        scopes.push(proto_scope_to_token_scope(scope)?);
     }
 
     let context = input.context.clone();
@@ -232,27 +219,27 @@ pub fn authorizer_to_proto_authorizer(input: &AuthorizerPolicies) -> schema::Aut
         .facts
         .iter()
         .map(|f| f.convert(&mut symbols))
-        .map(|f| v2::token_fact_to_proto_fact(&f))
+        .map(|f| token_fact_to_proto_fact(&f))
         .collect();
 
     let rules = input
         .rules
         .iter()
         .map(|r| r.convert(&mut symbols))
-        .map(|r| v2::token_rule_to_proto_rule(&r))
+        .map(|r| token_rule_to_proto_rule(&r))
         .collect();
 
     let checks = input
         .checks
         .iter()
         .map(|c| c.convert(&mut symbols))
-        .map(|c| v2::token_check_to_proto_check(&c))
+        .map(|c| token_check_to_proto_check(&c))
         .collect();
 
     let policies = input
         .policies
         .iter()
-        .map(|p| v2::policy_to_proto_policy(p, &mut symbols))
+        .map(|p| policy_to_proto_policy(p, &mut symbols))
         .collect();
 
     schema::AuthorizerPolicies {
@@ -286,27 +273,27 @@ pub fn proto_authorizer_to_authorizer(
 
     for fact in input.facts.iter() {
         facts.push(crate::builder::Fact::convert_from(
-            &v2::proto_fact_to_token_fact(fact)?,
+            &proto_fact_to_token_fact(fact)?,
             &symbols,
         )?);
     }
 
     for rule in input.rules.iter() {
         rules.push(crate::builder::Rule::convert_from(
-            &v2::proto_rule_to_token_rule(rule, version)?.0,
+            &proto_rule_to_token_rule(rule, version)?.0,
             &symbols,
         )?);
     }
 
     for check in input.checks.iter() {
         checks.push(crate::builder::Check::convert_from(
-            &v2::proto_check_to_token_check(check, version)?,
+            &proto_check_to_token_check(check, version)?,
             &symbols,
         )?);
     }
 
     for policy in input.policies.iter() {
-        policies.push(v2::proto_policy_to_policy(policy, &symbols, version)?);
+        policies.push(proto_policy_to_policy(policy, &symbols, version)?);
     }
 
     Ok(AuthorizerPolicies {
@@ -318,574 +305,557 @@ pub fn proto_authorizer_to_authorizer(
     })
 }
 
-pub mod v2 {
-    use super::schema;
-    use crate::builder::Convert;
-    use crate::datalog::*;
-    use crate::error;
-    use crate::format::schema::Empty;
-    use crate::format::schema::MapEntry;
-    use crate::token::Scope;
-    use crate::token::DATALOG_3_1;
+pub fn token_fact_to_proto_fact(input: &Fact) -> schema::Fact {
+    schema::Fact {
+        predicate: token_predicate_to_proto_predicate(&input.predicate),
+    }
+}
 
-    use std::collections::BTreeMap;
-    use std::collections::BTreeSet;
+pub fn proto_fact_to_token_fact(input: &schema::Fact) -> Result<Fact, error::Format> {
+    Ok(Fact {
+        predicate: proto_predicate_to_token_predicate(&input.predicate)?,
+    })
+}
 
-    pub fn token_fact_to_proto_fact(input: &Fact) -> schema::Fact {
-        schema::Fact {
-            predicate: token_predicate_to_proto_predicate(&input.predicate),
-        }
+pub fn token_check_to_proto_check(input: &Check) -> schema::Check {
+    use schema::check::Kind;
+
+    schema::Check {
+        queries: input.queries.iter().map(token_rule_to_proto_rule).collect(),
+        kind: match input.kind {
+            crate::token::builder::CheckKind::One => None,
+            crate::token::builder::CheckKind::All => Some(Kind::All as i32),
+            crate::token::builder::CheckKind::Reject => Some(Kind::Reject as i32),
+        },
+    }
+}
+
+pub fn proto_check_to_token_check(
+    input: &schema::Check,
+    version: u32,
+) -> Result<Check, error::Format> {
+    let mut queries = vec![];
+
+    for q in input.queries.iter() {
+        queries.push(proto_rule_to_token_rule(q, version)?.0);
     }
 
-    pub fn proto_fact_to_token_fact(input: &schema::Fact) -> Result<Fact, error::Format> {
-        Ok(Fact {
-            predicate: proto_predicate_to_token_predicate(&input.predicate)?,
-        })
-    }
-
-    pub fn token_check_to_proto_check(input: &Check) -> schema::Check {
-        use schema::check::Kind;
-
-        schema::Check {
-            queries: input.queries.iter().map(token_rule_to_proto_rule).collect(),
-            kind: match input.kind {
-                crate::token::builder::CheckKind::One => None,
-                crate::token::builder::CheckKind::All => Some(Kind::All as i32),
-                crate::token::builder::CheckKind::Reject => Some(Kind::Reject as i32),
-            },
-        }
-    }
-
-    pub fn proto_check_to_token_check(
-        input: &schema::Check,
-        version: u32,
-    ) -> Result<Check, error::Format> {
-        let mut queries = vec![];
-
-        for q in input.queries.iter() {
-            queries.push(proto_rule_to_token_rule(q, version)?.0);
-        }
-
-        let kind = match input.kind {
-            None | Some(0) => crate::token::builder::CheckKind::One,
-            Some(1) => crate::token::builder::CheckKind::All,
-            Some(2) => crate::token::builder::CheckKind::Reject,
-            _ => {
-                return Err(error::Format::DeserializationError(
-                    "deserialization error: invalid check kind".to_string(),
-                ))
-            }
-        };
-
-        Ok(Check { queries, kind })
-    }
-
-    pub fn policy_to_proto_policy(
-        input: &crate::token::builder::Policy,
-        symbols: &mut SymbolTable,
-    ) -> schema::Policy {
-        schema::Policy {
-            queries: input
-                .queries
-                .iter()
-                .map(|q| q.convert(symbols))
-                .map(|r| token_rule_to_proto_rule(&r))
-                .collect(),
-            kind: match input.kind {
-                crate::token::builder::PolicyKind::Allow => schema::policy::Kind::Allow as i32,
-                crate::token::builder::PolicyKind::Deny => schema::policy::Kind::Deny as i32,
-            },
-        }
-    }
-
-    pub fn proto_policy_to_policy(
-        input: &schema::Policy,
-        symbols: &SymbolTable,
-        version: u32,
-    ) -> Result<crate::token::builder::Policy, error::Format> {
-        use schema::policy::Kind;
-        let mut queries = vec![];
-
-        for q in input.queries.iter() {
-            let (c, _scopes) = proto_rule_to_token_rule(q, version)?;
-            let c = crate::token::builder::Rule::convert_from(&c, symbols)?;
-            queries.push(c);
-        }
-
-        let kind = if let Some(i) = Kind::from_i32(input.kind) {
-            i
-        } else {
+    let kind = match input.kind {
+        None | Some(0) => crate::token::builder::CheckKind::One,
+        Some(1) => crate::token::builder::CheckKind::All,
+        Some(2) => crate::token::builder::CheckKind::Reject,
+        _ => {
             return Err(error::Format::DeserializationError(
-                "deserialization error: invalid policy kind".to_string(),
-            ));
-        };
+                "deserialization error: invalid check kind".to_string(),
+            ))
+        }
+    };
 
-        let kind = match kind {
-            Kind::Allow => crate::token::builder::PolicyKind::Allow,
-            Kind::Deny => crate::token::builder::PolicyKind::Deny,
-        };
+    Ok(Check { queries, kind })
+}
 
-        Ok(crate::token::builder::Policy { queries, kind })
+pub fn policy_to_proto_policy(
+    input: &crate::token::builder::Policy,
+    symbols: &mut SymbolTable,
+) -> schema::Policy {
+    schema::Policy {
+        queries: input
+            .queries
+            .iter()
+            .map(|q| q.convert(symbols))
+            .map(|r| token_rule_to_proto_rule(&r))
+            .collect(),
+        kind: match input.kind {
+            crate::token::builder::PolicyKind::Allow => schema::policy::Kind::Allow as i32,
+            crate::token::builder::PolicyKind::Deny => schema::policy::Kind::Deny as i32,
+        },
+    }
+}
+
+pub fn proto_policy_to_policy(
+    input: &schema::Policy,
+    symbols: &SymbolTable,
+    version: u32,
+) -> Result<crate::token::builder::Policy, error::Format> {
+    use schema::policy::Kind;
+    let mut queries = vec![];
+
+    for q in input.queries.iter() {
+        let (c, _scopes) = proto_rule_to_token_rule(q, version)?;
+        let c = crate::token::builder::Rule::convert_from(&c, symbols)?;
+        queries.push(c);
     }
 
-    pub fn token_rule_to_proto_rule(input: &Rule) -> schema::Rule {
-        schema::Rule {
-            head: token_predicate_to_proto_predicate(&input.head),
-            body: input
-                .body
-                .iter()
-                .map(token_predicate_to_proto_predicate)
-                .collect(),
-            expressions: input
-                .expressions
-                .iter()
-                .map(token_expression_to_proto_expression)
-                .collect(),
-            scope: input
-                .scopes
-                .iter()
-                .map(token_scope_to_proto_scope)
-                .collect(),
-        }
+    let kind = if let Some(i) = Kind::from_i32(input.kind) {
+        i
+    } else {
+        return Err(error::Format::DeserializationError(
+            "deserialization error: invalid policy kind".to_string(),
+        ));
+    };
+
+    let kind = match kind {
+        Kind::Allow => crate::token::builder::PolicyKind::Allow,
+        Kind::Deny => crate::token::builder::PolicyKind::Deny,
+    };
+
+    Ok(crate::token::builder::Policy { queries, kind })
+}
+
+pub fn token_rule_to_proto_rule(input: &Rule) -> schema::Rule {
+    schema::Rule {
+        head: token_predicate_to_proto_predicate(&input.head),
+        body: input
+            .body
+            .iter()
+            .map(token_predicate_to_proto_predicate)
+            .collect(),
+        expressions: input
+            .expressions
+            .iter()
+            .map(token_expression_to_proto_expression)
+            .collect(),
+        scope: input
+            .scopes
+            .iter()
+            .map(token_scope_to_proto_scope)
+            .collect(),
+    }
+}
+
+pub fn proto_rule_to_token_rule(
+    input: &schema::Rule,
+    version: u32,
+) -> Result<(Rule, Vec<Scope>), error::Format> {
+    let mut body = vec![];
+
+    for p in input.body.iter() {
+        body.push(proto_predicate_to_token_predicate(p)?);
     }
 
-    pub fn proto_rule_to_token_rule(
-        input: &schema::Rule,
-        version: u32,
-    ) -> Result<(Rule, Vec<Scope>), error::Format> {
-        let mut body = vec![];
+    let mut expressions = vec![];
 
-        for p in input.body.iter() {
-            body.push(proto_predicate_to_token_predicate(p)?);
+    for c in input.expressions.iter() {
+        expressions.push(proto_expression_to_token_expression(c)?);
+    }
+
+    if version < DATALOG_3_1 && !input.scope.is_empty() {
+        return Err(error::Format::DeserializationError(
+            "deserialization error: scopes are only supported in datalog v3.1+".to_string(),
+        ));
+    }
+
+    let scopes: Result<Vec<_>, _> = input.scope.iter().map(proto_scope_to_token_scope).collect();
+    let scopes = scopes?;
+
+    Ok((
+        Rule {
+            head: proto_predicate_to_token_predicate(&input.head)?,
+            body,
+            expressions,
+            scopes: scopes.clone(),
+        },
+        scopes,
+    ))
+}
+
+pub fn token_predicate_to_proto_predicate(input: &Predicate) -> schema::Predicate {
+    schema::Predicate {
+        name: input.name,
+        terms: input.terms.iter().map(token_term_to_proto_id).collect(),
+    }
+}
+
+pub fn proto_predicate_to_token_predicate(
+    input: &schema::Predicate,
+) -> Result<Predicate, error::Format> {
+    let mut terms = vec![];
+
+    for term in input.terms.iter() {
+        terms.push(proto_id_to_token_term(term)?);
+    }
+
+    Ok(Predicate {
+        name: input.name,
+        terms,
+    })
+}
+
+pub fn token_term_to_proto_id(input: &Term) -> schema::Term {
+    use schema::term::Content;
+
+    match input {
+        Term::Variable(v) => schema::Term {
+            content: Some(Content::Variable(*v)),
+        },
+        Term::Integer(i) => schema::Term {
+            content: Some(Content::Integer(*i)),
+        },
+        Term::Str(s) => schema::Term {
+            content: Some(Content::String(*s)),
+        },
+        Term::Date(d) => schema::Term {
+            content: Some(Content::Date(*d)),
+        },
+        Term::Bytes(s) => schema::Term {
+            content: Some(Content::Bytes(s.clone())),
+        },
+        Term::Bool(b) => schema::Term {
+            content: Some(Content::Bool(*b)),
+        },
+        Term::Set(s) => schema::Term {
+            content: Some(Content::Set(schema::TermSet {
+                set: s.iter().map(token_term_to_proto_id).collect(),
+            })),
+        },
+        Term::Null => schema::Term {
+            content: Some(Content::Null(Empty {})),
+        },
+        Term::Array(a) => schema::Term {
+            content: Some(Content::Array(schema::Array {
+                array: a.iter().map(token_term_to_proto_id).collect(),
+            })),
+        },
+        Term::Map(m) => schema::Term {
+            content: Some(Content::Map(schema::Map {
+                entries: m
+                    .iter()
+                    .map(|(key, term)| {
+                        let key = match key {
+                            MapKey::Integer(i) => schema::MapKey {
+                                content: Some(schema::map_key::Content::Integer(*i)),
+                            },
+                            MapKey::Str(s) => schema::MapKey {
+                                content: Some(schema::map_key::Content::String(*s)),
+                            },
+                        };
+                        schema::MapEntry {
+                            key,
+                            value: token_term_to_proto_id(term),
+                        }
+                    })
+                    .collect(),
+            })),
+        },
+    }
+}
+
+pub fn proto_id_to_token_term(input: &schema::Term) -> Result<Term, error::Format> {
+    use schema::term::Content;
+
+    match &input.content {
+        None => Err(error::Format::DeserializationError(
+            "deserialization error: ID content enum is empty".to_string(),
+        )),
+        Some(Content::Variable(i)) => Ok(Term::Variable(*i)),
+        Some(Content::Integer(i)) => Ok(Term::Integer(*i)),
+        Some(Content::String(s)) => Ok(Term::Str(*s)),
+        Some(Content::Date(i)) => Ok(Term::Date(*i)),
+        Some(Content::Bytes(s)) => Ok(Term::Bytes(s.clone())),
+        Some(Content::Bool(b)) => Ok(Term::Bool(*b)),
+        Some(Content::Set(s)) => {
+            let mut kind: Option<u8> = None;
+            let mut set = BTreeSet::new();
+
+            for i in s.set.iter() {
+                let index = match i.content {
+                    Some(Content::Variable(_)) => {
+                        return Err(error::Format::DeserializationError(
+                            "deserialization error: sets cannot contain variables".to_string(),
+                        ));
+                    }
+                    Some(Content::Integer(_)) => 2,
+                    Some(Content::String(_)) => 3,
+                    Some(Content::Date(_)) => 4,
+                    Some(Content::Bytes(_)) => 5,
+                    Some(Content::Bool(_)) => 6,
+                    Some(Content::Set(_)) => {
+                        return Err(error::Format::DeserializationError(
+                            "deserialization error: sets cannot contain other sets".to_string(),
+                        ));
+                    }
+                    Some(Content::Null(_)) => 8,
+                    Some(Content::Array(_)) => 9,
+                    Some(Content::Map(_)) => 10,
+                    None => {
+                        return Err(error::Format::DeserializationError(
+                            "deserialization error: ID content enum is empty".to_string(),
+                        ))
+                    }
+                };
+
+                if let Some(k) = kind.as_ref() {
+                    if *k != index {
+                        return Err(error::Format::DeserializationError(
+                            "deserialization error: sets elements must have the same type"
+                                .to_string(),
+                        ));
+                    }
+                } else {
+                    kind = Some(index);
+                }
+
+                set.insert(proto_id_to_token_term(i)?);
+            }
+
+            Ok(Term::Set(set))
         }
+        Some(Content::Null(_)) => Ok(Term::Null),
+        Some(Content::Array(a)) => {
+            let array = a
+                .array
+                .iter()
+                .map(proto_id_to_token_term)
+                .collect::<Result<_, _>>()?;
 
-        let mut expressions = vec![];
-
-        for c in input.expressions.iter() {
-            expressions.push(proto_expression_to_token_expression(c)?);
+            Ok(Term::Array(array))
         }
+        Some(Content::Map(m)) => {
+            let mut map = BTreeMap::new();
 
-        if version < DATALOG_3_1 && !input.scope.is_empty() {
+            for MapEntry { key, value } in m.entries.iter() {
+                let key = match key.content {
+                    Some(schema::map_key::Content::Integer(i)) => MapKey::Integer(i),
+                    Some(schema::map_key::Content::String(s)) => MapKey::Str(s),
+                    None => {
+                        return Err(error::Format::DeserializationError(
+                            "deserialization error: ID content enum is empty".to_string(),
+                        ))
+                    }
+                };
+
+                map.insert(key, proto_id_to_token_term(&value)?);
+            }
+
+            Ok(Term::Map(map))
+        }
+    }
+}
+
+fn token_op_to_proto_op(op: &Op) -> schema::Op {
+    let content = match op {
+        Op::Value(i) => schema::op::Content::Value(token_term_to_proto_id(i)),
+        Op::Unary(u) => {
+            use schema::op_unary::Kind;
+
+            schema::op::Content::Unary(schema::OpUnary {
+                kind: match u {
+                    Unary::Negate => Kind::Negate,
+                    Unary::Parens => Kind::Parens,
+                    Unary::Length => Kind::Length,
+                    Unary::TypeOf => Kind::TypeOf,
+                    Unary::Ffi(_) => Kind::Ffi,
+                } as i32,
+                ffi_name: match u {
+                    Unary::Ffi(name) => Some(name.to_owned()),
+                    _ => None,
+                },
+            })
+        }
+        Op::Binary(b) => {
+            use schema::op_binary::Kind;
+
+            schema::op::Content::Binary(schema::OpBinary {
+                kind: match b {
+                    Binary::LessThan => Kind::LessThan,
+                    Binary::GreaterThan => Kind::GreaterThan,
+                    Binary::LessOrEqual => Kind::LessOrEqual,
+                    Binary::GreaterOrEqual => Kind::GreaterOrEqual,
+                    Binary::Equal => Kind::Equal,
+                    Binary::Contains => Kind::Contains,
+                    Binary::Prefix => Kind::Prefix,
+                    Binary::Suffix => Kind::Suffix,
+                    Binary::Regex => Kind::Regex,
+                    Binary::Add => Kind::Add,
+                    Binary::Sub => Kind::Sub,
+                    Binary::Mul => Kind::Mul,
+                    Binary::Div => Kind::Div,
+                    Binary::And => Kind::And,
+                    Binary::Or => Kind::Or,
+                    Binary::Intersection => Kind::Intersection,
+                    Binary::Union => Kind::Union,
+                    Binary::BitwiseAnd => Kind::BitwiseAnd,
+                    Binary::BitwiseOr => Kind::BitwiseOr,
+                    Binary::BitwiseXor => Kind::BitwiseXor,
+                    Binary::NotEqual => Kind::NotEqual,
+                    Binary::HeterogeneousEqual => Kind::HeterogeneousEqual,
+                    Binary::HeterogeneousNotEqual => Kind::HeterogeneousNotEqual,
+                    Binary::LazyAnd => Kind::LazyAnd,
+                    Binary::LazyOr => Kind::LazyOr,
+                    Binary::All => Kind::All,
+                    Binary::Any => Kind::Any,
+                    Binary::Get => Kind::Get,
+                    Binary::Ffi(_) => Kind::Ffi,
+                    Binary::TryOr => Kind::TryOr,
+                } as i32,
+                ffi_name: match b {
+                    Binary::Ffi(name) => Some(name.to_owned()),
+                    _ => None,
+                },
+            })
+        }
+        Op::Closure(params, ops) => schema::op::Content::Closure(schema::OpClosure {
+            params: params.clone(),
+            ops: ops.iter().map(token_op_to_proto_op).collect(),
+        }),
+    };
+
+    schema::Op {
+        content: Some(content),
+    }
+}
+
+pub fn token_expression_to_proto_expression(input: &Expression) -> schema::Expression {
+    schema::Expression {
+        ops: input.ops.iter().map(token_op_to_proto_op).collect(),
+    }
+}
+
+fn proto_op_to_token_op(op: &schema::Op) -> Result<Op, error::Format> {
+    use schema::{op, op_binary, op_unary};
+    Ok(match op.content.as_ref() {
+        Some(op::Content::Value(id)) => Op::Value(proto_id_to_token_term(id)?),
+        Some(op::Content::Unary(u)) => {
+            match (op_unary::Kind::from_i32(u.kind), u.ffi_name.as_ref()) {
+                (Some(op_unary::Kind::Negate), None) => Op::Unary(Unary::Negate),
+                (Some(op_unary::Kind::Parens), None) => Op::Unary(Unary::Parens),
+                (Some(op_unary::Kind::Length), None) => Op::Unary(Unary::Length),
+                (Some(op_unary::Kind::TypeOf), None) => Op::Unary(Unary::TypeOf),
+                (Some(op_unary::Kind::Ffi), Some(n)) => Op::Unary(Unary::Ffi(*n)),
+                (Some(op_unary::Kind::Ffi), None) => {
+                    return Err(error::Format::DeserializationError(
+                        "deserialization error: missing ffi name".to_string(),
+                    ))
+                }
+                (Some(_), Some(_)) => {
+                    return Err(error::Format::DeserializationError(
+                        "deserialization error: ffi name set on a regular unary operation"
+                            .to_string(),
+                    ))
+                }
+                (None, _) => {
+                    return Err(error::Format::DeserializationError(
+                        "deserialization error: unary operation is empty".to_string(),
+                    ))
+                }
+            }
+        }
+        Some(op::Content::Binary(b)) => {
+            match (op_binary::Kind::from_i32(b.kind), b.ffi_name.as_ref()) {
+                (Some(op_binary::Kind::LessThan), None) => Op::Binary(Binary::LessThan),
+                (Some(op_binary::Kind::GreaterThan), None) => Op::Binary(Binary::GreaterThan),
+                (Some(op_binary::Kind::LessOrEqual), None) => Op::Binary(Binary::LessOrEqual),
+                (Some(op_binary::Kind::GreaterOrEqual), None) => Op::Binary(Binary::GreaterOrEqual),
+                (Some(op_binary::Kind::Equal), None) => Op::Binary(Binary::Equal),
+                (Some(op_binary::Kind::Contains), None) => Op::Binary(Binary::Contains),
+                (Some(op_binary::Kind::Prefix), None) => Op::Binary(Binary::Prefix),
+                (Some(op_binary::Kind::Suffix), None) => Op::Binary(Binary::Suffix),
+                (Some(op_binary::Kind::Regex), None) => Op::Binary(Binary::Regex),
+                (Some(op_binary::Kind::Add), None) => Op::Binary(Binary::Add),
+                (Some(op_binary::Kind::Sub), None) => Op::Binary(Binary::Sub),
+                (Some(op_binary::Kind::Mul), None) => Op::Binary(Binary::Mul),
+                (Some(op_binary::Kind::Div), None) => Op::Binary(Binary::Div),
+                (Some(op_binary::Kind::And), None) => Op::Binary(Binary::And),
+                (Some(op_binary::Kind::Or), None) => Op::Binary(Binary::Or),
+                (Some(op_binary::Kind::Intersection), None) => Op::Binary(Binary::Intersection),
+                (Some(op_binary::Kind::Union), None) => Op::Binary(Binary::Union),
+                (Some(op_binary::Kind::BitwiseAnd), None) => Op::Binary(Binary::BitwiseAnd),
+                (Some(op_binary::Kind::BitwiseOr), None) => Op::Binary(Binary::BitwiseOr),
+                (Some(op_binary::Kind::BitwiseXor), None) => Op::Binary(Binary::BitwiseXor),
+                (Some(op_binary::Kind::NotEqual), None) => Op::Binary(Binary::NotEqual),
+                (Some(op_binary::Kind::HeterogeneousEqual), None) => {
+                    Op::Binary(Binary::HeterogeneousEqual)
+                }
+                (Some(op_binary::Kind::HeterogeneousNotEqual), None) => {
+                    Op::Binary(Binary::HeterogeneousNotEqual)
+                }
+                (Some(op_binary::Kind::LazyAnd), None) => Op::Binary(Binary::LazyAnd),
+                (Some(op_binary::Kind::LazyOr), None) => Op::Binary(Binary::LazyOr),
+                (Some(op_binary::Kind::All), None) => Op::Binary(Binary::All),
+                (Some(op_binary::Kind::Any), None) => Op::Binary(Binary::Any),
+                (Some(op_binary::Kind::Get), None) => Op::Binary(Binary::Get),
+                (Some(op_binary::Kind::Ffi), Some(n)) => Op::Binary(Binary::Ffi(*n)),
+                (Some(op_binary::Kind::Ffi), None) => {
+                    return Err(error::Format::DeserializationError(
+                        "deserialization error: missing ffi name".to_string(),
+                    ))
+                }
+                (Some(_), Some(_)) => {
+                    return Err(error::Format::DeserializationError(
+                        "deserialization error: ffi name set on a regular binary operation"
+                            .to_string(),
+                    ))
+                }
+                (Some(op_binary::Kind::TryOr), None) => Op::Binary(Binary::TryOr),
+                (None, _) => {
+                    return Err(error::Format::DeserializationError(
+                        "deserialization error: binary operation is empty".to_string(),
+                    ))
+                }
+            }
+        }
+        Some(op::Content::Closure(op_closure)) => Op::Closure(
+            op_closure.params.clone(),
+            op_closure
+                .ops
+                .iter()
+                .map(proto_op_to_token_op)
+                .collect::<Result<_, _>>()?,
+        ),
+        None => {
             return Err(error::Format::DeserializationError(
-                "deserialization error: scopes are only supported in datalog v3.1+".to_string(),
-            ));
+                "deserialization error: operation is empty".to_string(),
+            ))
         }
+    })
+}
 
-        let scopes: Result<Vec<_>, _> =
-            input.scope.iter().map(proto_scope_to_token_scope).collect();
-        let scopes = scopes?;
+pub fn proto_expression_to_token_expression(
+    input: &schema::Expression,
+) -> Result<Expression, error::Format> {
+    let mut ops = Vec::new();
 
-        Ok((
-            Rule {
-                head: proto_predicate_to_token_predicate(&input.head)?,
-                body,
-                expressions,
-                scopes: scopes.clone(),
-            },
-            scopes,
-        ))
+    for op in input.ops.iter() {
+        ops.push(proto_op_to_token_op(op)?);
     }
 
-    pub fn token_predicate_to_proto_predicate(input: &Predicate) -> schema::Predicate {
-        schema::Predicate {
-            name: input.name,
-            terms: input.terms.iter().map(token_term_to_proto_id).collect(),
-        }
-    }
+    Ok(Expression { ops })
+}
 
-    pub fn proto_predicate_to_token_predicate(
-        input: &schema::Predicate,
-    ) -> Result<Predicate, error::Format> {
-        let mut terms = vec![];
-
-        for term in input.terms.iter() {
-            terms.push(proto_id_to_token_term(term)?);
-        }
-
-        Ok(Predicate {
-            name: input.name,
-            terms,
-        })
-    }
-
-    pub fn token_term_to_proto_id(input: &Term) -> schema::Term {
-        use schema::term::Content;
-
-        match input {
-            Term::Variable(v) => schema::Term {
-                content: Some(Content::Variable(*v)),
-            },
-            Term::Integer(i) => schema::Term {
-                content: Some(Content::Integer(*i)),
-            },
-            Term::Str(s) => schema::Term {
-                content: Some(Content::String(*s)),
-            },
-            Term::Date(d) => schema::Term {
-                content: Some(Content::Date(*d)),
-            },
-            Term::Bytes(s) => schema::Term {
-                content: Some(Content::Bytes(s.clone())),
-            },
-            Term::Bool(b) => schema::Term {
-                content: Some(Content::Bool(*b)),
-            },
-            Term::Set(s) => schema::Term {
-                content: Some(Content::Set(schema::TermSet {
-                    set: s.iter().map(token_term_to_proto_id).collect(),
-                })),
-            },
-            Term::Null => schema::Term {
-                content: Some(Content::Null(Empty {})),
-            },
-            Term::Array(a) => schema::Term {
-                content: Some(Content::Array(schema::Array {
-                    array: a.iter().map(token_term_to_proto_id).collect(),
-                })),
-            },
-            Term::Map(m) => schema::Term {
-                content: Some(Content::Map(schema::Map {
-                    entries: m
-                        .iter()
-                        .map(|(key, term)| {
-                            let key = match key {
-                                MapKey::Integer(i) => schema::MapKey {
-                                    content: Some(schema::map_key::Content::Integer(*i)),
-                                },
-                                MapKey::Str(s) => schema::MapKey {
-                                    content: Some(schema::map_key::Content::String(*s)),
-                                },
-                            };
-                            schema::MapEntry {
-                                key,
-                                value: token_term_to_proto_id(term),
-                            }
-                        })
-                        .collect(),
-                })),
-            },
-        }
-    }
-
-    pub fn proto_id_to_token_term(input: &schema::Term) -> Result<Term, error::Format> {
-        use schema::term::Content;
-
-        match &input.content {
-            None => Err(error::Format::DeserializationError(
-                "deserialization error: ID content enum is empty".to_string(),
-            )),
-            Some(Content::Variable(i)) => Ok(Term::Variable(*i)),
-            Some(Content::Integer(i)) => Ok(Term::Integer(*i)),
-            Some(Content::String(s)) => Ok(Term::Str(*s)),
-            Some(Content::Date(i)) => Ok(Term::Date(*i)),
-            Some(Content::Bytes(s)) => Ok(Term::Bytes(s.clone())),
-            Some(Content::Bool(b)) => Ok(Term::Bool(*b)),
-            Some(Content::Set(s)) => {
-                let mut kind: Option<u8> = None;
-                let mut set = BTreeSet::new();
-
-                for i in s.set.iter() {
-                    let index = match i.content {
-                        Some(Content::Variable(_)) => {
-                            return Err(error::Format::DeserializationError(
-                                "deserialization error: sets cannot contain variables".to_string(),
-                            ));
-                        }
-                        Some(Content::Integer(_)) => 2,
-                        Some(Content::String(_)) => 3,
-                        Some(Content::Date(_)) => 4,
-                        Some(Content::Bytes(_)) => 5,
-                        Some(Content::Bool(_)) => 6,
-                        Some(Content::Set(_)) => {
-                            return Err(error::Format::DeserializationError(
-                                "deserialization error: sets cannot contain other sets".to_string(),
-                            ));
-                        }
-                        Some(Content::Null(_)) => 8,
-                        Some(Content::Array(_)) => 9,
-                        Some(Content::Map(_)) => 10,
-                        None => {
-                            return Err(error::Format::DeserializationError(
-                                "deserialization error: ID content enum is empty".to_string(),
-                            ))
-                        }
-                    };
-
-                    if let Some(k) = kind.as_ref() {
-                        if *k != index {
-                            return Err(error::Format::DeserializationError(
-                                "deserialization error: sets elements must have the same type"
-                                    .to_string(),
-                            ));
-                        }
-                    } else {
-                        kind = Some(index);
-                    }
-
-                    set.insert(proto_id_to_token_term(i)?);
-                }
-
-                Ok(Term::Set(set))
+pub fn token_scope_to_proto_scope(input: &Scope) -> schema::Scope {
+    schema::Scope {
+        content: Some(match input {
+            crate::token::Scope::Authority => {
+                schema::scope::Content::ScopeType(schema::scope::ScopeType::Authority as i32)
             }
-            Some(Content::Null(_)) => Ok(Term::Null),
-            Some(Content::Array(a)) => {
-                let array = a
-                    .array
-                    .iter()
-                    .map(proto_id_to_token_term)
-                    .collect::<Result<_, _>>()?;
-
-                Ok(Term::Array(array))
+            crate::token::Scope::Previous => {
+                schema::scope::Content::ScopeType(schema::scope::ScopeType::Previous as i32)
             }
-            Some(Content::Map(m)) => {
-                let mut map = BTreeMap::new();
-
-                for MapEntry { key, value } in m.entries.iter() {
-                    let key = match key.content {
-                        Some(schema::map_key::Content::Integer(i)) => MapKey::Integer(i),
-                        Some(schema::map_key::Content::String(s)) => MapKey::Str(s),
-                        None => {
-                            return Err(error::Format::DeserializationError(
-                                "deserialization error: ID content enum is empty".to_string(),
-                            ))
-                        }
-                    };
-
-                    map.insert(key, proto_id_to_token_term(&value)?);
-                }
-
-                Ok(Term::Map(map))
-            }
-        }
+            crate::token::Scope::PublicKey(i) => schema::scope::Content::PublicKey(*i as i64),
+        }),
     }
+}
 
-    fn token_op_to_proto_op(op: &Op) -> schema::Op {
-        let content = match op {
-            Op::Value(i) => schema::op::Content::Value(token_term_to_proto_id(i)),
-            Op::Unary(u) => {
-                use schema::op_unary::Kind;
-
-                schema::op::Content::Unary(schema::OpUnary {
-                    kind: match u {
-                        Unary::Negate => Kind::Negate,
-                        Unary::Parens => Kind::Parens,
-                        Unary::Length => Kind::Length,
-                        Unary::TypeOf => Kind::TypeOf,
-                        Unary::Ffi(_) => Kind::Ffi,
-                    } as i32,
-                    ffi_name: match u {
-                        Unary::Ffi(name) => Some(name.to_owned()),
-                        _ => None,
-                    },
-                })
-            }
-            Op::Binary(b) => {
-                use schema::op_binary::Kind;
-
-                schema::op::Content::Binary(schema::OpBinary {
-                    kind: match b {
-                        Binary::LessThan => Kind::LessThan,
-                        Binary::GreaterThan => Kind::GreaterThan,
-                        Binary::LessOrEqual => Kind::LessOrEqual,
-                        Binary::GreaterOrEqual => Kind::GreaterOrEqual,
-                        Binary::Equal => Kind::Equal,
-                        Binary::Contains => Kind::Contains,
-                        Binary::Prefix => Kind::Prefix,
-                        Binary::Suffix => Kind::Suffix,
-                        Binary::Regex => Kind::Regex,
-                        Binary::Add => Kind::Add,
-                        Binary::Sub => Kind::Sub,
-                        Binary::Mul => Kind::Mul,
-                        Binary::Div => Kind::Div,
-                        Binary::And => Kind::And,
-                        Binary::Or => Kind::Or,
-                        Binary::Intersection => Kind::Intersection,
-                        Binary::Union => Kind::Union,
-                        Binary::BitwiseAnd => Kind::BitwiseAnd,
-                        Binary::BitwiseOr => Kind::BitwiseOr,
-                        Binary::BitwiseXor => Kind::BitwiseXor,
-                        Binary::NotEqual => Kind::NotEqual,
-                        Binary::HeterogeneousEqual => Kind::HeterogeneousEqual,
-                        Binary::HeterogeneousNotEqual => Kind::HeterogeneousNotEqual,
-                        Binary::LazyAnd => Kind::LazyAnd,
-                        Binary::LazyOr => Kind::LazyOr,
-                        Binary::All => Kind::All,
-                        Binary::Any => Kind::Any,
-                        Binary::Get => Kind::Get,
-                        Binary::Ffi(_) => Kind::Ffi,
-                        Binary::TryOr => Kind::TryOr,
-                    } as i32,
-                    ffi_name: match b {
-                        Binary::Ffi(name) => Some(name.to_owned()),
-                        _ => None,
-                    },
-                })
-            }
-            Op::Closure(params, ops) => schema::op::Content::Closure(schema::OpClosure {
-                params: params.clone(),
-                ops: ops.iter().map(token_op_to_proto_op).collect(),
-            }),
-        };
-
-        schema::Op {
-            content: Some(content),
-        }
-    }
-
-    pub fn token_expression_to_proto_expression(input: &Expression) -> schema::Expression {
-        schema::Expression {
-            ops: input.ops.iter().map(token_op_to_proto_op).collect(),
-        }
-    }
-
-    fn proto_op_to_token_op(op: &schema::Op) -> Result<Op, error::Format> {
-        use schema::{op, op_binary, op_unary};
-        Ok(match op.content.as_ref() {
-            Some(op::Content::Value(id)) => Op::Value(proto_id_to_token_term(id)?),
-            Some(op::Content::Unary(u)) => {
-                match (op_unary::Kind::from_i32(u.kind), u.ffi_name.as_ref()) {
-                    (Some(op_unary::Kind::Negate), None) => Op::Unary(Unary::Negate),
-                    (Some(op_unary::Kind::Parens), None) => Op::Unary(Unary::Parens),
-                    (Some(op_unary::Kind::Length), None) => Op::Unary(Unary::Length),
-                    (Some(op_unary::Kind::TypeOf), None) => Op::Unary(Unary::TypeOf),
-                    (Some(op_unary::Kind::Ffi), Some(n)) => Op::Unary(Unary::Ffi(*n)),
-                    (Some(op_unary::Kind::Ffi), None) => {
-                        return Err(error::Format::DeserializationError(
-                            "deserialization error: missing ffi name".to_string(),
-                        ))
-                    }
-                    (Some(_), Some(_)) => {
-                        return Err(error::Format::DeserializationError(
-                            "deserialization error: ffi name set on a regular unary operation"
-                                .to_string(),
-                        ))
-                    }
-                    (None, _) => {
-                        return Err(error::Format::DeserializationError(
-                            "deserialization error: unary operation is empty".to_string(),
-                        ))
-                    }
+pub fn proto_scope_to_token_scope(input: &schema::Scope) -> Result<Scope, error::Format> {
+    //FIXME: check that the referenced public key index exists in the public key table
+    match input.content.as_ref() {
+        Some(content) => match content {
+            schema::scope::Content::ScopeType(i) => {
+                if *i == schema::scope::ScopeType::Authority as i32 {
+                    Ok(Scope::Authority)
+                } else if *i == schema::scope::ScopeType::Previous as i32 {
+                    Ok(Scope::Previous)
+                } else {
+                    Err(error::Format::DeserializationError(format!(
+                        "deserialization error: unexpected value `{}` for scope type",
+                        i
+                    )))
                 }
             }
-            Some(op::Content::Binary(b)) => {
-                match (op_binary::Kind::from_i32(b.kind), b.ffi_name.as_ref()) {
-                    (Some(op_binary::Kind::LessThan), None) => Op::Binary(Binary::LessThan),
-                    (Some(op_binary::Kind::GreaterThan), None) => Op::Binary(Binary::GreaterThan),
-                    (Some(op_binary::Kind::LessOrEqual), None) => Op::Binary(Binary::LessOrEqual),
-                    (Some(op_binary::Kind::GreaterOrEqual), None) => {
-                        Op::Binary(Binary::GreaterOrEqual)
-                    }
-                    (Some(op_binary::Kind::Equal), None) => Op::Binary(Binary::Equal),
-                    (Some(op_binary::Kind::Contains), None) => Op::Binary(Binary::Contains),
-                    (Some(op_binary::Kind::Prefix), None) => Op::Binary(Binary::Prefix),
-                    (Some(op_binary::Kind::Suffix), None) => Op::Binary(Binary::Suffix),
-                    (Some(op_binary::Kind::Regex), None) => Op::Binary(Binary::Regex),
-                    (Some(op_binary::Kind::Add), None) => Op::Binary(Binary::Add),
-                    (Some(op_binary::Kind::Sub), None) => Op::Binary(Binary::Sub),
-                    (Some(op_binary::Kind::Mul), None) => Op::Binary(Binary::Mul),
-                    (Some(op_binary::Kind::Div), None) => Op::Binary(Binary::Div),
-                    (Some(op_binary::Kind::And), None) => Op::Binary(Binary::And),
-                    (Some(op_binary::Kind::Or), None) => Op::Binary(Binary::Or),
-                    (Some(op_binary::Kind::Intersection), None) => Op::Binary(Binary::Intersection),
-                    (Some(op_binary::Kind::Union), None) => Op::Binary(Binary::Union),
-                    (Some(op_binary::Kind::BitwiseAnd), None) => Op::Binary(Binary::BitwiseAnd),
-                    (Some(op_binary::Kind::BitwiseOr), None) => Op::Binary(Binary::BitwiseOr),
-                    (Some(op_binary::Kind::BitwiseXor), None) => Op::Binary(Binary::BitwiseXor),
-                    (Some(op_binary::Kind::NotEqual), None) => Op::Binary(Binary::NotEqual),
-                    (Some(op_binary::Kind::HeterogeneousEqual), None) => {
-                        Op::Binary(Binary::HeterogeneousEqual)
-                    }
-                    (Some(op_binary::Kind::HeterogeneousNotEqual), None) => {
-                        Op::Binary(Binary::HeterogeneousNotEqual)
-                    }
-                    (Some(op_binary::Kind::LazyAnd), None) => Op::Binary(Binary::LazyAnd),
-                    (Some(op_binary::Kind::LazyOr), None) => Op::Binary(Binary::LazyOr),
-                    (Some(op_binary::Kind::All), None) => Op::Binary(Binary::All),
-                    (Some(op_binary::Kind::Any), None) => Op::Binary(Binary::Any),
-                    (Some(op_binary::Kind::Get), None) => Op::Binary(Binary::Get),
-                    (Some(op_binary::Kind::Ffi), Some(n)) => Op::Binary(Binary::Ffi(*n)),
-                    (Some(op_binary::Kind::Ffi), None) => {
-                        return Err(error::Format::DeserializationError(
-                            "deserialization error: missing ffi name".to_string(),
-                        ))
-                    }
-                    (Some(_), Some(_)) => {
-                        return Err(error::Format::DeserializationError(
-                            "deserialization error: ffi name set on a regular binary operation"
-                                .to_string(),
-                        ))
-                    }
-                    (Some(op_binary::Kind::TryOr), None) => Op::Binary(Binary::TryOr),
-                    (None, _) => {
-                        return Err(error::Format::DeserializationError(
-                            "deserialization error: binary operation is empty".to_string(),
-                        ))
-                    }
-                }
-            }
-            Some(op::Content::Closure(op_closure)) => Op::Closure(
-                op_closure.params.clone(),
-                op_closure
-                    .ops
-                    .iter()
-                    .map(proto_op_to_token_op)
-                    .collect::<Result<_, _>>()?,
-            ),
-            None => {
-                return Err(error::Format::DeserializationError(
-                    "deserialization error: operation is empty".to_string(),
-                ))
-            }
-        })
-    }
-
-    pub fn proto_expression_to_token_expression(
-        input: &schema::Expression,
-    ) -> Result<Expression, error::Format> {
-        let mut ops = Vec::new();
-
-        for op in input.ops.iter() {
-            ops.push(proto_op_to_token_op(op)?);
-        }
-
-        Ok(Expression { ops })
-    }
-
-    pub fn token_scope_to_proto_scope(input: &Scope) -> schema::Scope {
-        schema::Scope {
-            content: Some(match input {
-                crate::token::Scope::Authority => {
-                    schema::scope::Content::ScopeType(schema::scope::ScopeType::Authority as i32)
-                }
-                crate::token::Scope::Previous => {
-                    schema::scope::Content::ScopeType(schema::scope::ScopeType::Previous as i32)
-                }
-                crate::token::Scope::PublicKey(i) => schema::scope::Content::PublicKey(*i as i64),
-            }),
-        }
-    }
-
-    pub fn proto_scope_to_token_scope(input: &schema::Scope) -> Result<Scope, error::Format> {
-        //FIXME: check that the referenced public key index exists in the public key table
-        match input.content.as_ref() {
-            Some(content) => match content {
-                schema::scope::Content::ScopeType(i) => {
-                    if *i == schema::scope::ScopeType::Authority as i32 {
-                        Ok(Scope::Authority)
-                    } else if *i == schema::scope::ScopeType::Previous as i32 {
-                        Ok(Scope::Previous)
-                    } else {
-                        Err(error::Format::DeserializationError(format!(
-                            "deserialization error: unexpected value `{}` for scope type",
-                            i
-                        )))
-                    }
-                }
-                schema::scope::Content::PublicKey(i) => Ok(Scope::PublicKey(*i as u64)),
-            },
-            None => Err(error::Format::DeserializationError(
-                "deserialization error: expected `content` field in Scope".to_string(),
-            )),
-        }
+            schema::scope::Content::PublicKey(i) => Ok(Scope::PublicKey(*i as u64)),
+        },
+        None => Err(error::Format::DeserializationError(
+            "deserialization error: expected `content` field in Scope".to_string(),
+        )),
     }
 }

--- a/biscuit-auth/src/format/schema.proto
+++ b/biscuit-auth/src/format/schema.proto
@@ -44,9 +44,9 @@ message Block {
   repeated string symbols = 1;
   optional string context = 2;
   optional uint32 version = 3;
-  repeated FactV2 facts_v2 = 4;
-  repeated RuleV2 rules_v2 = 5;
-  repeated CheckV2 checks_v2 = 6;
+  repeated Fact facts = 4;
+  repeated Rule rules = 5;
+  repeated Check checks = 6;
   repeated Scope scope = 7;
   repeated PublicKey publicKeys = 8;
 }
@@ -63,19 +63,19 @@ message Scope {
   }
 }
 
-message FactV2 {
-  required PredicateV2 predicate = 1;
+message Fact {
+  required Predicate predicate = 1;
 }
 
-message RuleV2 {
-  required PredicateV2 head = 1;
-  repeated PredicateV2 body = 2;
-  repeated ExpressionV2 expressions = 3;
+message Rule {
+  required Predicate head = 1;
+  repeated Predicate body = 2;
+  repeated Expression expressions = 3;
   repeated Scope scope = 4;
 }
 
-message CheckV2 {
-  repeated RuleV2 queries = 1;
+message Check {
+  repeated Rule queries = 1;
   optional Kind kind = 2;
 
   enum Kind {
@@ -85,12 +85,12 @@ message CheckV2 {
   }
 }
 
-message PredicateV2 {
+message Predicate {
   required uint64 name = 1;
-  repeated TermV2 terms = 2;
+  repeated Term terms = 2;
 }
 
-message TermV2 {
+message Term {
   oneof Content {
     uint32 variable = 1;
     int64 integer = 2;
@@ -106,11 +106,11 @@ message TermV2 {
 }
 
 message TermSet {
-  repeated TermV2 set = 1;
+  repeated Term set = 1;
 }
 
 message Array {
-  repeated TermV2 array = 1;
+  repeated Term array = 1;
 }
 
 message Map {
@@ -119,7 +119,7 @@ message Map {
 
 message MapEntry {
   required MapKey key = 1;
-  required TermV2 value = 2;
+  required Term value = 2;
 }
 
 message MapKey {
@@ -129,13 +129,13 @@ message MapKey {
   }
 }
 
-message ExpressionV2 {
+message Expression {
   repeated Op ops = 1;
 }
 
 message Op {
   oneof Content {
-    TermV2 value = 1;
+    Term value = 1;
     OpUnary unary = 2;
     OpBinary Binary = 3;
     OpClosure closure = 4;
@@ -204,16 +204,16 @@ message Policy {
     Deny = 1;
   }
 
-  repeated RuleV2 queries = 1;
+  repeated Rule queries = 1;
   required Kind kind = 2;
 }
 
 message AuthorizerPolicies {
   repeated string symbols = 1;
   optional uint32 version = 2;
-  repeated FactV2 facts = 3;
-  repeated RuleV2 rules = 4;
-  repeated CheckV2 checks = 5;
+  repeated Fact facts = 3;
+  repeated Rule rules = 4;
+  repeated Check checks = 5;
   repeated Policy policies = 6;
 }
 
@@ -263,15 +263,15 @@ message Empty {}
 
 message GeneratedFacts {
   repeated Origin origins = 1;
-  repeated FactV2 facts = 2;
+  repeated Fact facts = 2;
 }
 
 message SnapshotBlock {
   optional string context = 1;
   optional uint32 version = 2;
-  repeated FactV2 facts_v2 = 3;
-  repeated RuleV2 rules_v2 = 4;
-  repeated CheckV2 checks_v2 = 5;
+  repeated Fact facts = 3;
+  repeated Rule rules = 4;
+  repeated Check checks = 5;
   repeated Scope scope = 6;
   optional PublicKey externalKey = 7;
 }

--- a/biscuit-auth/src/format/schema.rs
+++ b/biscuit-auth/src/format/schema.rs
@@ -69,11 +69,11 @@ pub struct Block {
     #[prost(uint32, optional, tag="3")]
     pub version: ::core::option::Option<u32>,
     #[prost(message, repeated, tag="4")]
-    pub facts_v2: ::prost::alloc::vec::Vec<FactV2>,
+    pub facts: ::prost::alloc::vec::Vec<Fact>,
     #[prost(message, repeated, tag="5")]
-    pub rules_v2: ::prost::alloc::vec::Vec<RuleV2>,
+    pub rules: ::prost::alloc::vec::Vec<Rule>,
     #[prost(message, repeated, tag="6")]
-    pub checks_v2: ::prost::alloc::vec::Vec<CheckV2>,
+    pub checks: ::prost::alloc::vec::Vec<Check>,
     #[prost(message, repeated, tag="7")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
     #[prost(message, repeated, tag="8")]
@@ -101,30 +101,30 @@ pub mod scope {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FactV2 {
+pub struct Fact {
     #[prost(message, required, tag="1")]
-    pub predicate: PredicateV2,
+    pub predicate: Predicate,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RuleV2 {
+pub struct Rule {
     #[prost(message, required, tag="1")]
-    pub head: PredicateV2,
+    pub head: Predicate,
     #[prost(message, repeated, tag="2")]
-    pub body: ::prost::alloc::vec::Vec<PredicateV2>,
+    pub body: ::prost::alloc::vec::Vec<Predicate>,
     #[prost(message, repeated, tag="3")]
-    pub expressions: ::prost::alloc::vec::Vec<ExpressionV2>,
+    pub expressions: ::prost::alloc::vec::Vec<Expression>,
     #[prost(message, repeated, tag="4")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CheckV2 {
+pub struct Check {
     #[prost(message, repeated, tag="1")]
-    pub queries: ::prost::alloc::vec::Vec<RuleV2>,
-    #[prost(enumeration="check_v2::Kind", optional, tag="2")]
+    pub queries: ::prost::alloc::vec::Vec<Rule>,
+    #[prost(enumeration="check::Kind", optional, tag="2")]
     pub kind: ::core::option::Option<i32>,
 }
-/// Nested message and enum types in `CheckV2`.
-pub mod check_v2 {
+/// Nested message and enum types in `Check`.
+pub mod check {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
@@ -134,19 +134,19 @@ pub mod check_v2 {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PredicateV2 {
+pub struct Predicate {
     #[prost(uint64, required, tag="1")]
     pub name: u64,
     #[prost(message, repeated, tag="2")]
-    pub terms: ::prost::alloc::vec::Vec<TermV2>,
+    pub terms: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TermV2 {
-    #[prost(oneof="term_v2::Content", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
-    pub content: ::core::option::Option<term_v2::Content>,
+pub struct Term {
+    #[prost(oneof="term::Content", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    pub content: ::core::option::Option<term::Content>,
 }
-/// Nested message and enum types in `TermV2`.
-pub mod term_v2 {
+/// Nested message and enum types in `Term`.
+pub mod term {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
         #[prost(uint32, tag="1")]
@@ -174,12 +174,12 @@ pub mod term_v2 {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TermSet {
     #[prost(message, repeated, tag="1")]
-    pub set: ::prost::alloc::vec::Vec<TermV2>,
+    pub set: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Array {
     #[prost(message, repeated, tag="1")]
-    pub array: ::prost::alloc::vec::Vec<TermV2>,
+    pub array: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Map {
@@ -191,7 +191,7 @@ pub struct MapEntry {
     #[prost(message, required, tag="1")]
     pub key: MapKey,
     #[prost(message, required, tag="2")]
-    pub value: TermV2,
+    pub value: Term,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapKey {
@@ -209,7 +209,7 @@ pub mod map_key {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExpressionV2 {
+pub struct Expression {
     #[prost(message, repeated, tag="1")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
@@ -223,7 +223,7 @@ pub mod op {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
         #[prost(message, tag="1")]
-        Value(super::TermV2),
+        Value(super::Term),
         #[prost(message, tag="2")]
         Unary(super::OpUnary),
         #[prost(message, tag="3")]
@@ -305,7 +305,7 @@ pub struct OpClosure {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
     #[prost(message, repeated, tag="1")]
-    pub queries: ::prost::alloc::vec::Vec<RuleV2>,
+    pub queries: ::prost::alloc::vec::Vec<Rule>,
     #[prost(enumeration="policy::Kind", required, tag="2")]
     pub kind: i32,
 }
@@ -325,11 +325,11 @@ pub struct AuthorizerPolicies {
     #[prost(uint32, optional, tag="2")]
     pub version: ::core::option::Option<u32>,
     #[prost(message, repeated, tag="3")]
-    pub facts: ::prost::alloc::vec::Vec<FactV2>,
+    pub facts: ::prost::alloc::vec::Vec<Fact>,
     #[prost(message, repeated, tag="4")]
-    pub rules: ::prost::alloc::vec::Vec<RuleV2>,
+    pub rules: ::prost::alloc::vec::Vec<Rule>,
     #[prost(message, repeated, tag="5")]
-    pub checks: ::prost::alloc::vec::Vec<CheckV2>,
+    pub checks: ::prost::alloc::vec::Vec<Check>,
     #[prost(message, repeated, tag="6")]
     pub policies: ::prost::alloc::vec::Vec<Policy>,
 }
@@ -409,7 +409,7 @@ pub struct GeneratedFacts {
     #[prost(message, repeated, tag="1")]
     pub origins: ::prost::alloc::vec::Vec<Origin>,
     #[prost(message, repeated, tag="2")]
-    pub facts: ::prost::alloc::vec::Vec<FactV2>,
+    pub facts: ::prost::alloc::vec::Vec<Fact>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotBlock {
@@ -418,11 +418,11 @@ pub struct SnapshotBlock {
     #[prost(uint32, optional, tag="2")]
     pub version: ::core::option::Option<u32>,
     #[prost(message, repeated, tag="3")]
-    pub facts_v2: ::prost::alloc::vec::Vec<FactV2>,
+    pub facts: ::prost::alloc::vec::Vec<Fact>,
     #[prost(message, repeated, tag="4")]
-    pub rules_v2: ::prost::alloc::vec::Vec<RuleV2>,
+    pub rules: ::prost::alloc::vec::Vec<Rule>,
     #[prost(message, repeated, tag="5")]
-    pub checks_v2: ::prost::alloc::vec::Vec<CheckV2>,
+    pub checks: ::prost::alloc::vec::Vec<Check>,
     #[prost(message, repeated, tag="6")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
     #[prost(message, optional, tag="7")]

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -11,11 +11,9 @@ use crate::{
     error,
     format::{
         convert::{
+            policy_to_proto_policy, proto_fact_to_token_fact, proto_policy_to_policy,
             proto_snapshot_block_to_token_block, token_block_to_proto_snapshot_block,
-            v2::{
-                policy_to_proto_policy, proto_fact_to_token_fact, proto_policy_to_policy,
-                token_fact_to_proto_fact,
-            },
+            token_fact_to_proto_fact,
         },
         schema::{self, GeneratedFacts},
     },

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -19,8 +19,8 @@ use crate::{
     error,
     format::{
         convert::{
-            proto_snapshot_block_to_token_block, token_block_to_proto_snapshot_block,
-            v2::{policy_to_proto_policy, proto_policy_to_policy},
+            policy_to_proto_policy, proto_policy_to_policy, proto_snapshot_block_to_token_block,
+            token_block_to_proto_snapshot_block,
         },
         schema,
     },


### PR DESCRIPTION
the "V2" tag was needed in previous versions where there were multiple alternative serializations for Datalog elements like facts. Since it is not needed anymore, we can remove it from the message and field names.

This changes the generated code, but will not affect the way tokens are serialized