### PR TITLE
fix: don’t rely on lists in closures sample

### DIFF
--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -2206,7 +2206,7 @@ fn closures(target: &str, root: &KeyPair, test: bool) -> TestResult {
         validate_token(
             root,
             &data[..],
-            "allow if [true].any($p -> [true].all($p -> $p))",
+            r#"allow if { "true" }.any($p -> { "true" }.all($p -> $p))"#,
         ),
     );
 

--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -3054,7 +3054,7 @@ result: `Ok(0)`
 
 authorizer code:
 ```
-allow if [true].any($p -> [true].all($p -> $p));
+allow if {"true"}.any($p -> {"true"}.all($p -> $p));
 ```
 
 revocation ids:
@@ -3085,7 +3085,7 @@ World {
     },
 ]
   policies: [
-    "allow if [true].any($p -> [true].all($p -> $p))",
+    "allow if {\"true\"}.any($p -> {\"true\"}.all($p -> $p))",
 ]
 }
 ```

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -2850,7 +2850,7 @@
               }
             ],
             "policies": [
-              "allow if [true].any($p -> [true].all($p -> $p))"
+              "allow if {\"true\"}.any($p -> {\"true\"}.all($p -> $p))"
             ]
           },
           "result": {
@@ -2858,7 +2858,7 @@
               "Execution": "ShadowedVariable"
             }
           },
-          "authorizer_code": "allow if [true].any($p -> [true].all($p -> $p));\n",
+          "authorizer_code": "allow if {\"true\"}.any($p -> {\"true\"}.all($p -> $p));\n",
           "revocation_ids": [
             "2cd348b6df5f08b900903fd8d3fbea0bb89b665c331a2aa2131e0b8ecb38b3550275d4ccd8db35da6c4433eed1d456cfb761e3fcc7845894d891e986ca044b02"
           ]


### PR DESCRIPTION
The samples have been designed to map to specific features, in order to help gradual implementation of 3.3 features. The closures are meant to be implemented before lists and maps, so this sample should not rely on lists being implemented