### PR TITLE
Add support for generating Windows release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
           - os: ubuntu-latest
             target_arch: aarch64-unknown-linux-gnu
             arch: arm64-linux
+          - os: windows-latest
+            target_arch: x86_64-pc-windows-msvc
+            arch: x86_64-windows
+          - os: windows-latest
+            target_arch: i686-pc-windows-msvc
+            arch: i686-windows
+          - os: windows-latest
+            target_arch: aarch64-pc-windows-msvc
+            arch: arm64-windows
 
     steps:
       - name: Checkout sources
@@ -68,11 +77,23 @@ jobs:
           CARGO_C_VERSION: v0.10.13
         run: |
           curl -L $LINK/$CARGO_C_VERSION/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
+      - name: Install cargo-c (Windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/download
+          CARGO_C_FILE: cargo-c-windows-msvc.zip
+          CARGO_C_VERSION: v0.10.13
+        shell: cmd
+        run: |
+          curl -L %LINK%/%CARGO_C_VERSION%/%CARGO_C_FILE% -o %TEMP%\%CARGO_C_FILE%
+          tar xzf %TEMP%\%CARGO_C_FILE% -C %USERPROFILE%\.cargo\bin
+          del %TEMP%\%CARGO_C_FILE%
       - name: Run cargo-c tests
         run: cargo ctest --release --features="capi"
         if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-gnu'
 
       - name: Build C-API
+        shell: bash
         run: |
           cargo cinstall --target ${{ matrix.target_arch }} \
             --prefix=/usr \
@@ -83,8 +104,9 @@ jobs:
         run: tar cvzf biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz -C build/ .
 
       - name: Generate checksum
+        shell: bash
         run: |
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
+          if [[ "$RUNNER_OS" == "Linux" || "$RUNNER_OS" == "Windows" ]]; then
             sha256sum "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz" > "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz.sha256"
           else
             shasum -a 256 "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz" > "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz.sha256"


### PR DESCRIPTION
Three platforms are supported: x86_64, i686, and ARM64. There are the three user-land architectures supported by modern Windows ([arm32 was recently removed](https://learn.microsoft.com/en-us/windows/arm/arm32-to-arm64)). These platforms are supported by Rust as [tier 2 with host tools or above](https://doc.rust-lang.org/rustc/platform-support.html).

I've tested this PR in the following ways:

* trigged [a build](https://github.com/AustinWise/biscuit-rust/releases/tag/austin-test-11) and confirmed that all three architectures [generate assets](https://github.com/AustinWise/biscuit-rust/releases/tag/austin-test-11). 
* Downloaded the assets and confirmed that the `tar` command built into Windows 11 can extract the tar file.
* Used the x86_64, i686, and ARM64 DLL in my experimental [C# bindings](https://github.com/AustinWise/biscuit-csharp) to exercise several functions
* Statically linking on x86_64.

I ran into trouble with existing targets building. I'm pretty sure this is not caused by changes, see #290.