### PR TITLE
Don't use prefix argument when creating release for Windows.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,10 +95,17 @@ jobs:
       - name: Build C-API
         shell: bash
         run: |
-          cargo cinstall --target ${{ matrix.target_arch }} \
-            --prefix=/usr \
-            --destdir=./build \
-            --profile release-strip
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # Don't use --prefix on Windows, as there is no global location to install shared libraries and headers.
+            cargo cinstall --target ${{ matrix.target_arch }} \
+              --destdir=./build \
+              --profile release-strip
+          else
+            cargo cinstall --target ${{ matrix.target_arch }} \
+              --prefix=/usr \
+              --destdir=./build \
+              --profile release-strip
+          fi
 
       - name: Compress
         run: tar cvzf biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz -C build/ .


### PR DESCRIPTION
There is not really a global directory on Windows for installing shared libraries and headers. When we use "--prefix=/usr", the tarball ends up having a prefix of "Program Files\Git\usr\", which is confusing.

I confirmed that [the build seccueeds](https://github.com/AustinWise/biscuit-rust/actions/runs/16297747755) and [the tar balls](https://github.com/AustinWise/biscuit-rust/releases/tag/austin-test-19) have the expected directory structure.
