### PR TITLE
fix parameter confusion in macros

### DIFF
--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -173,13 +173,6 @@ pub trait ToAnyParam {
     fn to_any_param(&self) -> AnyParam;
 }
 
-#[cfg(feature = "datalog-macro")]
-impl ToAnyParam for PublicKey {
-    fn to_any_param(&self) -> AnyParam {
-        AnyParam::PublicKey(*self)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, convert::TryFrom};

--- a/biscuit-auth/src/token/builder/check.rs
+++ b/biscuit-auth/src/token/builder/check.rs
@@ -111,6 +111,16 @@ impl Check {
         }
     }
 
+    // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes
+    #[cfg(feature = "datalog-macro")]
+    pub fn set_macro_scope_param(
+        &mut self,
+        name: &str,
+        param: PublicKey,
+    ) -> Result<(), error::Token> {
+        self.set_scope_lenient(name, param)
+    }
+
     pub fn validate_parameters(&self) -> Result<(), error::Token> {
         for rule in &self.queries {
             rule.validate_parameters()?;

--- a/biscuit-auth/src/token/builder/policy.rs
+++ b/biscuit-auth/src/token/builder/policy.rs
@@ -104,6 +104,16 @@ impl Policy {
         }
     }
 
+    // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes
+    #[cfg(feature = "datalog-macro")]
+    pub fn set_macro_scope_param(
+        &mut self,
+        name: &str,
+        param: PublicKey,
+    ) -> Result<(), error::Token> {
+        self.set_scope_lenient(name, param)
+    }
+
     pub fn validate_parameters(&self) -> Result<(), error::Token> {
         for query in &self.queries {
             query.validate_parameters()?;

--- a/biscuit-auth/src/token/builder/rule.rs
+++ b/biscuit-auth/src/token/builder/rule.rs
@@ -258,6 +258,16 @@ impl Rule {
         }
     }
 
+    // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes
+    #[cfg(feature = "datalog-macro")]
+    pub fn set_macro_scope_param(
+        &mut self,
+        name: &str,
+        param: PublicKey,
+    ) -> Result<(), error::Token> {
+        self.set_scope_lenient(name, param)
+    }
+
     pub(super) fn apply_parameters(&mut self) {
         if let Some(parameters) = self.parameters.clone() {
             self.head.terms = self


### PR DESCRIPTION
macros resolve scope parameters and regular parameters through the `ToAnyParams` trait, losing the ability to discriminate between the two in a static way. This leads to panics instead of compilation errors.

Note: this PR fixes the issue of mistakenly providing a term-like value (most likely a string) where a public key is expected. It also removes the provided `impl ToAnyParam for PublicKey`. Since this implementation never makes sense with the other changes, it’s fine to remove it as a bugfix.
The code still uses `ToAnyParam` for datalog terms, which allows to provide a public key value when implementing it.
Completely removing this possibility requires removing the `ToAnyParam` conversion trait altogether, which requires careful thought. This is what #314 is about.

That being said, this PR already removes the possibility of honest mistakes when using macros, so it’s valuable in itself.

Fixes #301 

# ToDo

- [x] store separately parameters and scope parameters in `Item`
- [x] only use `ToAnyParam` for datalog terms
- [x] require `PublicKey` directly for scope params
- [x] remove `impl ToAnyParam for PublicKey`
- [ ] ~try using `Into<Term>` instead of `T: ToAnyParam`~
- [ ] ~try using `Into<(PublicKey, Vec<PublicKey>)>` instead of `PublicKey`~