### PR TITLE
fix: disable newly introduced rustc warning in parser

### DIFF
--- a/biscuit-parser/src/parser.rs
+++ b/biscuit-parser/src/parser.rs
@@ -2,6 +2,9 @@
  * Copyright (c) 2019 Geoffroy Couprie <contact@geoffroycouprie.com> and Contributors to the Eclipse Foundation.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// This warning makes all parser signatures extremely verbose
+#![allow(mismatched_lifetime_syntaxes)]
 use crate::builder::{self, CheckKind, PublicKey};
 use nom::{
     branch::alt,


### PR DESCRIPTION
it makes all the parser signatures extremely verbose:

```rust
pub fn fact(i: &'str) -> IResult<&str, builder::Fact, Error> {}
```
turns into

```rust
pub fn fact(i: &'_ str) -> IResult<&'_ str, builder::Fact, Error<'_>> {}
```


since `capi` has a no-warnings stance, let’s disable it