### PR TITLE
workspace: bump RustCrypto dependencies to new set of releases

### DIFF
--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -26,8 +26,8 @@ uuid = ["dep:uuid"]
 pem = ["ed25519-dalek/pem", "ed25519-dalek/pkcs8"]
 
 [dependencies]
-rand_core = "^0.6"
-sha2 = "^0.9"
+rand_core = "0.10"
+sha2 = "0.11"
 prost = "0.10"
 prost-types = "0.10"
 regex = { version = "1.5", default-features = false, features = ["std"] }
@@ -35,12 +35,12 @@ nom = { version = "7", default-features = false, features = ["std"] }
 hex = "0.4"
 zeroize = { version = "1.5", default-features = false }
 thiserror = "1"
-rand = { version = "0.8" }
+rand = { version = "0.10" }
 wasm-bindgen = { version = "0.2", optional = true }
 base64 = "0.13.0"
-ed25519-dalek = { version = "2.0.0", features = ["rand_core", "zeroize"] }
+ed25519-dalek = { version = "3", features = ["rand_core", "zeroize"] }
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
-getrandom = { version = "0.2.15" }
+getrandom = { version = "0.4" }
 time = { version = "0.3.7", features = ["formatting", "parsing"] }
 uuid = { version = "1", optional = true }
 biscuit-parser = { version = "0.2.0", path = "../biscuit-parser" }
@@ -49,14 +49,11 @@ chrono = { version = "0.4.26", optional = true, default-features = false, featur
   "serde",
 ] }
 serde_json = "1.0.117"
-ecdsa = { version = "0.16.9", features = ["signing", "verifying", "pem", "alloc", "pkcs8", "serde"] }
-p256 = "0.13.2"
-pkcs8 = "0.9.0"
-elliptic-curve = { version = "0.13.8", features = ["pkcs8"] }
+p256 = { version = "0.14", features = ["alloc", "pem", "pkcs8", "serde"] }
 
 [dev-dependencies]
 bencher = "0.1.5"
-rand = "0.8"
+rand = "0.10"
 chrono = { version = "0.4.26", features = ["serde", "clock"] }
 colored-diff = "0.2.3"
 prost-build = "0.10"

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -716,7 +716,7 @@ fn random_block(target: &str, root: &KeyPair, test: bool) -> TestResult {
     } else {
         let serialized = biscuit2.container();
         let mut proto = serialized.to_proto();
-        let arr: [u8; 32] = rng.gen();
+        let arr: [u8; 32] = rng.random();
         proto.blocks[0].block = Vec::from(&arr[..]);
         let mut data = Vec::new();
         proto.encode(&mut data).unwrap();

--- a/biscuit-auth/src/crypto/ed25519.rs
+++ b/biscuit-auth/src/crypto/ed25519.rs
@@ -19,7 +19,7 @@ use super::Signature;
 use ed25519_dalek::pkcs8::DecodePrivateKey;
 use ed25519_dalek::Signer;
 use ed25519_dalek::*;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, Rng};
 use std::{convert::TryInto, hash::Hash, ops::Drop};
 use zeroize::Zeroize;
 
@@ -30,7 +30,7 @@ pub struct KeyPair {
 }
 
 impl KeyPair {
-    pub fn new_with_rng<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
+    pub fn new_with_rng<T: Rng + CryptoRng + ?Sized>(rng: &mut T) -> Self {
         let kp = ed25519_dalek::SigningKey::generate(rng);
         KeyPair { kp }
     }

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -20,7 +20,7 @@ mod ed25519;
 mod p256;
 
 use nom::Finish;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, Rng};
 use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;
@@ -35,15 +35,15 @@ pub enum KeyPair {
 impl KeyPair {
     /// Create a new ed25519 keypair with the default OS RNG
     pub fn new() -> Self {
-        Self::new_with_rng(Algorithm::Ed25519, &mut rand::rngs::OsRng)
+        Self::new_with_rng(Algorithm::Ed25519, &mut rand::rng())
     }
 
     /// Create a new keypair with a chosen algorithm and the default OS RNG
     pub fn new_with_algorithm(algorithm: Algorithm) -> Self {
-        Self::new_with_rng(algorithm, &mut rand::rngs::OsRng)
+        Self::new_with_rng(algorithm, &mut rand::rng())
     }
 
-    pub fn new_with_rng<T: RngCore + CryptoRng>(algorithm: Algorithm, rng: &mut T) -> Self {
+    pub fn new_with_rng<T: Rng + CryptoRng + ?Sized>(algorithm: Algorithm, rng: &mut T) -> Self {
         match algorithm {
             Algorithm::Ed25519 => KeyPair::Ed25519(ed25519::KeyPair::new_with_rng(rng)),
             Algorithm::Secp256r1 => KeyPair::P256(p256::KeyPair::new_with_rng(rng)),

--- a/biscuit-auth/src/crypto/p256.rs
+++ b/biscuit-auth/src/crypto/p256.rs
@@ -9,9 +9,8 @@ use super::error;
 use super::Signature;
 
 use p256::ecdsa::{signature::Signer, signature::Verifier, SigningKey, VerifyingKey};
-use p256::elliptic_curve::rand_core::{CryptoRng, RngCore};
-use p256::NistP256;
-use std::hash::Hash;
+use p256::elliptic_curve::{rand_core::{CryptoRng, Rng},Generate};
+use std::{convert::TryInto, hash::Hash};
 
 /// pair of cryptographic keys used to sign a token's block
 #[derive(Debug, PartialEq)]
@@ -20,8 +19,8 @@ pub struct KeyPair {
 }
 
 impl KeyPair {
-    pub fn new_with_rng<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let kp = SigningKey::random(rng);
+    pub fn new_with_rng<T: Rng + CryptoRng + ?Sized>(rng: &mut T) -> Self {
+        let kp = SigningKey::generate_from_rng(rng);
 
         KeyPair { kp }
     }
@@ -37,15 +36,19 @@ impl KeyPair {
         if bytes.len() != 32 {
             return Err(Format::InvalidKeySize(bytes.len()));
         }
-        let kp = SigningKey::from_bytes(bytes.into())
-            .map_err(|s| s.to_string())
-            .map_err(Format::InvalidKey)?;
+        let kp = SigningKey::from_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| Format::InvalidKeySize(bytes.len()))?,
+        )
+        .map_err(|s| s.to_string())
+        .map_err(Format::InvalidKey)?;
 
         Ok(KeyPair { kp })
     }
 
     pub fn sign(&self, data: &[u8]) -> Result<Signature, error::Format> {
-        let signature: ecdsa::Signature<NistP256> = self
+        let signature: p256::ecdsa::Signature = self
             .kp
             .try_sign(data)
             .map_err(|s| s.to_string())
@@ -120,15 +123,14 @@ impl PrivateKey {
 
     /// deserializes from a big endian byte array
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, error::Format> {
-        // the version of generic-array used by p256 panics if the input length
-        // is incorrect (including when using `.try_into()`)
-        if bytes.len() != 32 {
-            return Err(Format::InvalidKeySize(bytes.len()));
-        }
-        SigningKey::from_bytes(bytes.into())
-            .map(PrivateKey)
-            .map_err(|s| s.to_string())
-            .map_err(Format::InvalidKey)
+        SigningKey::from_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| Format::InvalidKeySize(bytes.len()))?,
+        )
+        .map(PrivateKey)
+        .map_err(|s| s.to_string())
+        .map_err(Format::InvalidKey)
     }
 
     /// deserializes from an hex-encoded string
@@ -196,7 +198,7 @@ pub struct PublicKey(VerifyingKey);
 impl PublicKey {
     /// serializes to a byte array
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_encoded_point(true).to_bytes().into()
+        self.0.to_sec1_point(true).to_bytes().into()
     }
 
     /// serializes to an hex-encoded string

--- a/biscuit-auth/src/datalog/expression.rs
+++ b/biscuit-auth/src/datalog/expression.rs
@@ -8,10 +8,7 @@ use super::{MapKey, SymbolIndex, Term};
 use super::{SymbolTable, TemporarySymbolTable};
 use regex::Regex;
 use std::sync::Arc;
-use std::{
-    collections::HashMap,
-    convert::TryFrom,
-};
+use std::{collections::HashMap, convert::TryFrom};
 
 #[derive(Clone)]
 pub struct ExternFunc(

--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -151,46 +151,48 @@ impl Rule {
         let variables = MatchedVariables::new(self.variables_set());
 
         CombineIt::new(variables, &self.body, facts, symbols)
-        .map(move |(origin, variables)| {
-                    let mut temporary_symbols = TemporarySymbolTable::new(symbols);
-                    for e in self.expressions.iter() {
-                        match e.evaluate(&variables, &mut temporary_symbols, extern_funcs) {
-                            Ok(Term::Bool(true)) => {}
-                            Ok(Term::Bool(false)) => return Ok((origin, variables, false)),
-                            Ok(_) => return Err(error::Expression::InvalidType),
-                            Err(e) => {
-                                //println!("expr returned {:?}", res);
-                                return Err(e);
-                            }
+            .map(move |(origin, variables)| {
+                let mut temporary_symbols = TemporarySymbolTable::new(symbols);
+                for e in self.expressions.iter() {
+                    match e.evaluate(&variables, &mut temporary_symbols, extern_funcs) {
+                        Ok(Term::Bool(true)) => {}
+                        Ok(Term::Bool(false)) => return Ok((origin, variables, false)),
+                        Ok(_) => return Err(error::Expression::InvalidType),
+                        Err(e) => {
+                            //println!("expr returned {:?}", res);
+                            return Err(e);
                         }
                     }
-            Ok((origin, variables, true))
-        }).filter_map(move |res/*(mut origin,h, expression_res)*/| {
-            match res {
-                Ok((mut origin,h , expression_res)) => {
-                    if expression_res {
-                    let mut p = head.clone();
-                    for index in 0..p.terms.len() {
-                        match &p.terms[index] {
-                            Term::Variable(i) => match h.get(i) {
-                              Some(val) => p.terms[index] = val.clone(),
-                              None => {
-                                // head variables should be bound in the body predicates
-                                return None;
-                              }
-                            },
-                            _ => continue,
-                        };
+                }
+                Ok((origin, variables, true))
+            })
+            .filter_map(move |res /*(mut origin,h, expression_res)*/| {
+                match res {
+                    Ok((mut origin, h, expression_res)) => {
+                        if expression_res {
+                            let mut p = head.clone();
+                            for index in 0..p.terms.len() {
+                                match &p.terms[index] {
+                                    Term::Variable(i) => match h.get(i) {
+                                        Some(val) => p.terms[index] = val.clone(),
+                                        None => {
+                                            // head variables should be bound in the body predicates
+                                            return None;
+                                        }
+                                    },
+                                    _ => continue,
+                                };
+                            }
+
+                            origin.insert(rule_origin);
+                            Some(Ok((origin, Fact { predicate: p })))
+                        } else {
+                            None
+                        }
                     }
-
-                    origin.insert(rule_origin);
-                    Some(Ok((origin, Fact { predicate: p })))
-                } else {None}
-                },
-                Err(e) => Some(Err(e))
-            }
-
-        })
+                    Err(e) => Some(Err(e)),
+                }
+            })
     }
 
     pub fn find_match(

--- a/biscuit-auth/src/format/schema.rs
+++ b/biscuit-auth/src/format/schema.rs
@@ -1,39 +1,39 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Biscuit {
-    #[prost(uint32, optional, tag="1")]
+    #[prost(uint32, optional, tag = "1")]
     pub root_key_id: ::core::option::Option<u32>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub authority: SignedBlock,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub blocks: ::prost::alloc::vec::Vec<SignedBlock>,
-    #[prost(message, required, tag="4")]
+    #[prost(message, required, tag = "4")]
     pub proof: Proof,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedBlock {
-    #[prost(bytes="vec", required, tag="1")]
+    #[prost(bytes = "vec", required, tag = "1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub next_key: PublicKey,
-    #[prost(bytes="vec", required, tag="3")]
+    #[prost(bytes = "vec", required, tag = "3")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub external_signature: ::core::option::Option<ExternalSignature>,
-    #[prost(uint32, optional, tag="5")]
+    #[prost(uint32, optional, tag = "5")]
     pub version: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExternalSignature {
-    #[prost(bytes="vec", required, tag="1")]
+    #[prost(bytes = "vec", required, tag = "1")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub public_key: PublicKey,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublicKey {
-    #[prost(enumeration="public_key::Algorithm", required, tag="1")]
+    #[prost(enumeration = "public_key::Algorithm", required, tag = "1")]
     pub algorithm: i32,
-    #[prost(bytes="vec", required, tag="2")]
+    #[prost(bytes = "vec", required, tag = "2")]
     pub key: ::prost::alloc::vec::Vec<u8>,
 }
 /// Nested message and enum types in `PublicKey`.
@@ -47,41 +47,41 @@ pub mod public_key {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
-    #[prost(oneof="proof::Content", tags="1, 2")]
+    #[prost(oneof = "proof::Content", tags = "1, 2")]
     pub content: ::core::option::Option<proof::Content>,
 }
 /// Nested message and enum types in `Proof`.
 pub mod proof {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(bytes, tag="1")]
+        #[prost(bytes, tag = "1")]
         NextSecret(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag="2")]
+        #[prost(bytes, tag = "2")]
         FinalSignature(::prost::alloc::vec::Vec<u8>),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Block {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub context: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="3")]
+    #[prost(uint32, optional, tag = "3")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
-    #[prost(message, repeated, tag="8")]
+    #[prost(message, repeated, tag = "8")]
     pub public_keys: ::prost::alloc::vec::Vec<PublicKey>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Scope {
-    #[prost(oneof="scope::Content", tags="1, 2")]
+    #[prost(oneof = "scope::Content", tags = "1, 2")]
     pub content: ::core::option::Option<scope::Content>,
 }
 /// Nested message and enum types in `Scope`.
@@ -94,33 +94,33 @@ pub mod scope {
     }
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(enumeration="ScopeType", tag="1")]
+        #[prost(enumeration = "ScopeType", tag = "1")]
         ScopeType(i32),
-        #[prost(int64, tag="2")]
+        #[prost(int64, tag = "2")]
         PublicKey(i64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fact {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub predicate: Predicate,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Rule {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub head: Predicate,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub body: ::prost::alloc::vec::Vec<Predicate>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub expressions: ::prost::alloc::vec::Vec<Expression>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Check {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub queries: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(enumeration="check::Kind", optional, tag="2")]
+    #[prost(enumeration = "check::Kind", optional, tag = "2")]
     pub kind: ::core::option::Option<i32>,
 }
 /// Nested message and enum types in `Check`.
@@ -135,108 +135,108 @@ pub mod check {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Predicate {
-    #[prost(uint64, required, tag="1")]
+    #[prost(uint64, required, tag = "1")]
     pub name: u64,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub terms: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Term {
-    #[prost(oneof="term::Content", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof = "term::Content", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub content: ::core::option::Option<term::Content>,
 }
 /// Nested message and enum types in `Term`.
 pub mod term {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(uint32, tag="1")]
+        #[prost(uint32, tag = "1")]
         Variable(u32),
-        #[prost(int64, tag="2")]
+        #[prost(int64, tag = "2")]
         Integer(i64),
-        #[prost(uint64, tag="3")]
+        #[prost(uint64, tag = "3")]
         String(u64),
-        #[prost(uint64, tag="4")]
+        #[prost(uint64, tag = "4")]
         Date(u64),
-        #[prost(bytes, tag="5")]
+        #[prost(bytes, tag = "5")]
         Bytes(::prost::alloc::vec::Vec<u8>),
-        #[prost(bool, tag="6")]
+        #[prost(bool, tag = "6")]
         Bool(bool),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         Set(super::TermSet),
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         Null(super::Empty),
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         Array(super::Array),
-        #[prost(message, tag="10")]
+        #[prost(message, tag = "10")]
         Map(super::Map),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TermSet {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub set: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Array {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub array: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Map {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub entries: ::prost::alloc::vec::Vec<MapEntry>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapEntry {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub key: MapKey,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub value: Term,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapKey {
-    #[prost(oneof="map_key::Content", tags="1, 2")]
+    #[prost(oneof = "map_key::Content", tags = "1, 2")]
     pub content: ::core::option::Option<map_key::Content>,
 }
 /// Nested message and enum types in `MapKey`.
 pub mod map_key {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(int64, tag="1")]
+        #[prost(int64, tag = "1")]
         Integer(i64),
-        #[prost(uint64, tag="2")]
+        #[prost(uint64, tag = "2")]
         String(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Expression {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Op {
-    #[prost(oneof="op::Content", tags="1, 2, 3, 4")]
+    #[prost(oneof = "op::Content", tags = "1, 2, 3, 4")]
     pub content: ::core::option::Option<op::Content>,
 }
 /// Nested message and enum types in `Op`.
 pub mod op {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Value(super::Term),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Unary(super::OpUnary),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Binary(super::OpBinary),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         Closure(super::OpClosure),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpUnary {
-    #[prost(enumeration="op_unary::Kind", required, tag="1")]
+    #[prost(enumeration = "op_unary::Kind", required, tag = "1")]
     pub kind: i32,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub ffi_name: ::core::option::Option<u64>,
 }
 /// Nested message and enum types in `OpUnary`.
@@ -253,9 +253,9 @@ pub mod op_unary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpBinary {
-    #[prost(enumeration="op_binary::Kind", required, tag="1")]
+    #[prost(enumeration = "op_binary::Kind", required, tag = "1")]
     pub kind: i32,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub ffi_name: ::core::option::Option<u64>,
 }
 /// Nested message and enum types in `OpBinary`.
@@ -297,16 +297,16 @@ pub mod op_binary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpClosure {
-    #[prost(uint32, repeated, packed="false", tag="1")]
+    #[prost(uint32, repeated, packed = "false", tag = "1")]
     pub params: ::prost::alloc::vec::Vec<u32>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub queries: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(enumeration="policy::Kind", required, tag="2")]
+    #[prost(enumeration = "policy::Kind", required, tag = "2")]
     pub kind: i32,
 }
 /// Nested message and enum types in `Policy`.
@@ -320,111 +320,110 @@ pub mod policy {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerPolicies {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="2")]
+    #[prost(uint32, optional, tag = "2")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub policies: ::prost::alloc::vec::Vec<Policy>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ThirdPartyBlockRequest {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub legacy_previous_key: ::core::option::Option<PublicKey>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub legacy_public_keys: ::prost::alloc::vec::Vec<PublicKey>,
-    #[prost(bytes="vec", required, tag="3")]
+    #[prost(bytes = "vec", required, tag = "3")]
     pub previous_signature: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ThirdPartyBlockContents {
-    #[prost(bytes="vec", required, tag="1")]
+    #[prost(bytes = "vec", required, tag = "1")]
     pub payload: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub external_signature: ExternalSignature,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerSnapshot {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub limits: RunLimits,
-    #[prost(uint64, required, tag="2")]
+    #[prost(uint64, required, tag = "2")]
     pub execution_time: u64,
-    #[prost(message, required, tag="3")]
+    #[prost(message, required, tag = "3")]
     pub world: AuthorizerWorld,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunLimits {
-    #[prost(uint64, required, tag="1")]
+    #[prost(uint64, required, tag = "1")]
     pub max_facts: u64,
-    #[prost(uint64, required, tag="2")]
+    #[prost(uint64, required, tag = "2")]
     pub max_iterations: u64,
-    #[prost(uint64, required, tag="3")]
+    #[prost(uint64, required, tag = "3")]
     pub max_time: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerWorld {
-    #[prost(uint32, optional, tag="1")]
+    #[prost(uint32, optional, tag = "1")]
     pub version: ::core::option::Option<u32>,
-    #[prost(string, repeated, tag="2")]
+    #[prost(string, repeated, tag = "2")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub public_keys: ::prost::alloc::vec::Vec<PublicKey>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub blocks: ::prost::alloc::vec::Vec<SnapshotBlock>,
-    #[prost(message, required, tag="5")]
+    #[prost(message, required, tag = "5")]
     pub authorizer_block: SnapshotBlock,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub authorizer_policies: ::prost::alloc::vec::Vec<Policy>,
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub generated_facts: ::prost::alloc::vec::Vec<GeneratedFacts>,
-    #[prost(uint64, required, tag="8")]
+    #[prost(uint64, required, tag = "8")]
     pub iterations: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Origin {
-    #[prost(oneof="origin::Content", tags="1, 2")]
+    #[prost(oneof = "origin::Content", tags = "1, 2")]
     pub content: ::core::option::Option<origin::Content>,
 }
 /// Nested message and enum types in `Origin`.
 pub mod origin {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Authorizer(super::Empty),
-        #[prost(uint32, tag="2")]
+        #[prost(uint32, tag = "2")]
         Origin(u32),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Empty {
-}
+pub struct Empty {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedFacts {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub origins: ::prost::alloc::vec::Vec<Origin>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotBlock {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub context: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="2")]
+    #[prost(uint32, optional, tag = "2")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub external_key: ::core::option::Option<PublicKey>,
 }

--- a/biscuit-auth/src/time.rs
+++ b/biscuit-auth/src/time.rs
@@ -6,11 +6,12 @@
 //!
 //! code from <https://github.com/rust-lang/rust/issues/48564#issuecomment-698712971>
 
-#[cfg(feature = "wasm")]
-use std::convert::TryInto;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
+
+#[cfg(target_arch = "wasm32")]
 #[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::*;
+use {std::convert::TryInto,
+ wasm_bindgen::prelude::*};
 
 pub use std::time::*;
 

--- a/biscuit-auth/src/token/builder/biscuit.rs
+++ b/biscuit-auth/src/token/builder/biscuit.rs
@@ -8,7 +8,7 @@ use crate::crypto::PublicKey;
 use crate::datalog::SymbolTable;
 use crate::token::default_symbol_table;
 use crate::{error, Biscuit, KeyPair};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 use std::fmt;
 use std::time::SystemTime;
@@ -133,10 +133,10 @@ impl BiscuitBuilder {
         root_key: &KeyPair,
         symbols: SymbolTable,
     ) -> Result<Biscuit, error::Token> {
-        self.build_with_rng(root_key, symbols, &mut rand::rngs::OsRng)
+        self.build_with_rng(root_key, symbols, &mut rand::rng())
     }
 
-    pub fn build_with_rng<R: RngCore + CryptoRng>(
+    pub fn build_with_rng<R: Rng + CryptoRng + ?Sized>(
         self,
         root: &KeyPair,
         symbols: SymbolTable,

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -8,7 +8,7 @@ use std::iter::once;
 
 use builder::{BiscuitBuilder, BlockBuilder};
 use prost::Message;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, Rng};
 
 use self::public_keys::PublicKeys;
 use super::crypto::{KeyPair, PublicKey, Signature};
@@ -174,7 +174,7 @@ impl Biscuit {
     /// since the public key is integrated into the token, the keypair can be
     /// discarded right after calling this function
     pub fn append(&self, block_builder: BlockBuilder) -> Result<Self, error::Token> {
-        let keypair = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rand::rngs::OsRng);
+        let keypair = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rand::rng());
         self.append_with_keypair(&keypair, block_builder)
     }
 
@@ -251,7 +251,7 @@ impl Biscuit {
     /// creates a new token, using a provided CSPRNG
     ///
     /// the public part of the root keypair must be used for verification
-    pub(crate) fn new_with_rng<T: RngCore + CryptoRng>(
+    pub(crate) fn new_with_rng<T: Rng + CryptoRng + ?Sized>(
         rng: &mut T,
         root_key_id: Option<u32>,
         root: &KeyPair,
@@ -411,8 +411,7 @@ impl Biscuit {
         external_key: PublicKey,
         response: ThirdPartyBlock,
     ) -> Result<Self, error::Token> {
-        let next_keypair =
-            KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rand::rngs::OsRng);
+        let next_keypair = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rand::rng());
 
         self.append_third_party_with_keypair(external_key, response, next_keypair)
     }

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -105,8 +105,7 @@ impl UnverifiedBiscuit {
     /// since the public key is integrated into the token, the keypair can be
     /// discarded right after calling this function
     pub fn append(&self, block_builder: BlockBuilder) -> Result<Self, error::Token> {
-        let keypair =
-            KeyPair::new_with_rng(super::builder::Algorithm::Ed25519, &mut rand::rngs::OsRng);
+        let keypair = KeyPair::new_with_rng(super::builder::Algorithm::Ed25519, &mut rand::rng());
         self.append_with_keypair(&keypair, block_builder)
     }
 
@@ -301,7 +300,7 @@ impl UnverifiedBiscuit {
 
     pub fn append_third_party(&self, slice: &[u8]) -> Result<Self, error::Token> {
         let next_keypair =
-            KeyPair::new_with_rng(super::builder::Algorithm::Ed25519, &mut rand::rngs::OsRng);
+            KeyPair::new_with_rng(super::builder::Algorithm::Ed25519, &mut rand::rng());
         self.append_third_party_with_keypair(slice, next_keypair)
     }
 

--- a/biscuit-capi/Cargo.toml
+++ b/biscuit-capi/Cargo.toml
@@ -19,7 +19,7 @@ biscuit-auth = { version = "6.0.0", path = "../biscuit-auth", features = [
     "pem",
 ] }
 libc = "0.2"
-rand = "0.8"
+rand = "0.10"
 
 [dev-dependencies]
 inline-c = "0.1"

--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -9,8 +9,8 @@ use biscuit_parser::{
     error,
     parser::{parse_block_source, parse_source},
 };
-use proc_macro2::{Span, TokenStream};
 use manyhow::bail;
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::collections::{HashMap, HashSet};
 use syn::{
@@ -145,7 +145,9 @@ pub fn authorizer(input: proc_macro::TokenStream) -> manyhow::Result<proc_macro:
 /// and replaced by manual block building.
 #[manyhow::manyhow]
 #[proc_macro]
-pub fn authorizer_merge(input: proc_macro::TokenStream) -> manyhow::Result<proc_macro::TokenStream> {
+pub fn authorizer_merge(
+    input: proc_macro::TokenStream,
+) -> manyhow::Result<proc_macro::TokenStream> {
     let ParsedMerge {
         target,
         datalog,

--- a/biscuit-quote/tests/error_message.rs
+++ b/biscuit-quote/tests/error_message.rs
@@ -5,10 +5,10 @@
 //! Test for compilation error messages.
 //! Compile each file in tests/error_message/ and check that error messages haven't changed.
 //!
-//! run with `TRYBUILD=overwrite cargo test` to update the .stderr files containing expected error messages 
+//! run with `TRYBUILD=overwrite cargo test` to update the .stderr files containing expected error messages
 
 #[test]
-fn test_error_msg () {
+fn test_error_msg() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/error_message/*.rs");
 }


### PR DESCRIPTION
This is a very early attempt to update dependencies to use new releases of RustCrypto.

We (RustCrypto) don't have an final release yet, but this is meant to help test biscuit with code using pre-releases.