### PR TITLE
WIP: remove `ToAnyParam` and use `Into<Param>` instead

### DIFF
--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -173,13 +173,6 @@ pub trait ToAnyParam {
     fn to_any_param(&self) -> AnyParam;
 }
 
-#[cfg(feature = "datalog-macro")]
-impl ToAnyParam for PublicKey {
-    fn to_any_param(&self) -> AnyParam {
-        AnyParam::PublicKey(*self)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, convert::TryFrom};

--- a/biscuit-auth/src/token/builder/check.rs
+++ b/biscuit-auth/src/token/builder/check.rs
@@ -111,6 +111,16 @@ impl Check {
         }
     }
 
+    // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes
+    #[cfg(feature = "datalog-macro")]
+    pub fn set_macro_scope_param(
+        &mut self,
+        name: &str,
+        param: PublicKey,
+    ) -> Result<(), error::Token> {
+        self.set_scope_lenient(name, param)
+    }
+
     pub fn validate_parameters(&self) -> Result<(), error::Token> {
         for rule in &self.queries {
             rule.validate_parameters()?;

--- a/biscuit-auth/src/token/builder/check.rs
+++ b/biscuit-auth/src/token/builder/check.rs
@@ -11,8 +11,6 @@ use crate::{
     error, PublicKey,
 };
 
-#[cfg(feature = "datalog-macro")]
-use super::ToAnyParam;
 use super::{display_rule_body, Convert, Rule, Term};
 
 /// Builder for a Biscuit check
@@ -98,17 +96,12 @@ impl Check {
     }
 
     #[cfg(feature = "datalog-macro")]
-    pub fn set_macro_param<T: ToAnyParam>(
+    pub fn set_macro_param<T: Into<Term>>(
         &mut self,
         name: &str,
         param: T,
     ) -> Result<(), error::Token> {
-        use super::AnyParam;
-
-        match param.to_any_param() {
-            AnyParam::Term(t) => self.set_lenient(name, t),
-            AnyParam::PublicKey(p) => self.set_scope_lenient(name, p),
-        }
+        self.set_lenient(name, param.into())
     }
 
     // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes

--- a/biscuit-auth/src/token/builder/fact.rs
+++ b/biscuit-auth/src/token/builder/fact.rs
@@ -11,8 +11,6 @@ use crate::{
     error,
 };
 
-#[cfg(feature = "datalog-macro")]
-use super::ToAnyParam;
 use super::{Convert, Predicate, Term};
 
 /// Builder for a Datalog fact
@@ -115,17 +113,12 @@ impl Fact {
     }
 
     #[cfg(feature = "datalog-macro")]
-    pub fn set_macro_param<T: ToAnyParam>(
+    pub fn set_macro_param<T: Into<Term>>(
         &mut self,
         name: &str,
         param: T,
     ) -> Result<(), error::Token> {
-        use super::AnyParam;
-
-        match param.to_any_param() {
-            AnyParam::Term(t) => self.set_lenient(name, t),
-            AnyParam::PublicKey(_) => Ok(()),
-        }
+        self.set_lenient(name, param.into())
     }
 
     pub(super) fn apply_parameters(&mut self) {

--- a/biscuit-auth/src/token/builder/policy.rs
+++ b/biscuit-auth/src/token/builder/policy.rs
@@ -8,8 +8,6 @@ use nom::Finish;
 
 use crate::{error, PublicKey};
 
-#[cfg(feature = "datalog-macro")]
-use super::ToAnyParam;
 use super::{display_rule_body, Rule, Term};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,17 +89,12 @@ impl Policy {
     }
 
     #[cfg(feature = "datalog-macro")]
-    pub fn set_macro_param<T: ToAnyParam>(
+    pub fn set_macro_param<T: Into<Term>>(
         &mut self,
         name: &str,
         param: T,
     ) -> Result<(), error::Token> {
-        use super::AnyParam;
-
-        match param.to_any_param() {
-            AnyParam::Term(t) => self.set_lenient(name, t),
-            AnyParam::PublicKey(p) => self.set_scope_lenient(name, p),
-        }
+        self.set_lenient(name, param.into())
     }
 
     // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes

--- a/biscuit-auth/src/token/builder/policy.rs
+++ b/biscuit-auth/src/token/builder/policy.rs
@@ -104,6 +104,16 @@ impl Policy {
         }
     }
 
+    // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes
+    #[cfg(feature = "datalog-macro")]
+    pub fn set_macro_scope_param(
+        &mut self,
+        name: &str,
+        param: PublicKey,
+    ) -> Result<(), error::Token> {
+        self.set_scope_lenient(name, param)
+    }
+
     pub fn validate_parameters(&self) -> Result<(), error::Token> {
         for query in &self.queries {
             query.validate_parameters()?;

--- a/biscuit-auth/src/token/builder/rule.rs
+++ b/biscuit-auth/src/token/builder/rule.rs
@@ -258,6 +258,16 @@ impl Rule {
         }
     }
 
+    // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes
+    #[cfg(feature = "datalog-macro")]
+    pub fn set_macro_scope_param(
+        &mut self,
+        name: &str,
+        param: PublicKey,
+    ) -> Result<(), error::Token> {
+        self.set_scope_lenient(name, param)
+    }
+
     pub(super) fn apply_parameters(&mut self) {
         if let Some(parameters) = self.parameters.clone() {
             self.head.terms = self

--- a/biscuit-auth/src/token/builder/rule.rs
+++ b/biscuit-auth/src/token/builder/rule.rs
@@ -11,8 +11,6 @@ use crate::{
     error, PublicKey,
 };
 
-#[cfg(feature = "datalog-macro")]
-use super::ToAnyParam;
 use super::{Convert, Expression, Predicate, Scope, Term};
 
 /// Builder for a Datalog rule
@@ -245,17 +243,12 @@ impl Rule {
     }
 
     #[cfg(feature = "datalog-macro")]
-    pub fn set_macro_param<T: ToAnyParam>(
+    pub fn set_macro_param<T: Into<Term>>(
         &mut self,
         name: &str,
         param: T,
     ) -> Result<(), error::Token> {
-        use super::AnyParam;
-
-        match param.to_any_param() {
-            AnyParam::Term(t) => self.set_lenient(name, t),
-            AnyParam::PublicKey(pubkey) => self.set_scope_lenient(name, pubkey),
-        }
+        self.set_lenient(name, param.into())
     }
 
     // TODO maybe introduce a conversion trait to support refs, multiple values, non-pk scopes


### PR DESCRIPTION
Continuation of #302 

The goal is to:

- remove the possibility of passing a public key where a term is expected
- remove `ToAnyParam` in favor of `Into<AnyParam>` for simplicity
- (possibly) extend the passing of public keys to support multiple keys at once, and keywords.

The main difference is that `ToAnyParam` takes a reference, while `Into` consumes its input.

# todo

- [x] try using `Into<Term>` instead of `T: ToAnyParam`
- [ ] try using `Into<(PublicKey, Vec<PublicKey>)>` instead of `PublicKey`