### PR TITLE
Make wasm-bindgen optional for wasm32 target

### DIFF
--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/biscuit-auth/biscuit-rust"
 [features]
 default = ["regex-full", "datalog-macro", "pem"]
 regex-full = ["regex/perf", "regex/unicode"]
-wasm = ["wasm-bindgen"]
+wasm-bindgen = ["dep:wasm-bindgen"]
 # used by biscuit-wasm to serialize errors to JSON
 serde-error = ["serde", "biscuit-parser/serde-error"]
 # used by biscuit-quote to parse datalog at compile-time

--- a/biscuit-auth/src/time.rs
+++ b/biscuit-auth/src/time.rs
@@ -6,10 +6,10 @@
 //!
 //! code from <https://github.com/rust-lang/rust/issues/48564#issuecomment-698712971>
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 use std::convert::TryInto;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
-#[cfg(feature = "wasm")]
+#[cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::prelude::*;
 
 pub use std::time::*;
@@ -39,23 +39,28 @@ impl Instant {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[cfg(feature = "wasm")]
-#[wasm_bindgen(inline_js = r#"
-export function performance_now() {
-  return performance.now();
-}"#)]
-extern "C" {
-    fn performance_now() -> f64;
-}
-
-#[cfg(target_arch = "wasm32")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant(u64);
 
 #[cfg(target_arch = "wasm32")]
 impl Instant {
+    #[cfg(feature = "wasm-bindgen")]
     pub fn now() -> Self {
+        #[wasm_bindgen(inline_js = r#"
+        export function performance_now() {
+          return performance.now();
+        }"#)]
+        extern "C" {
+            fn performance_now() -> f64;
+        }
         Self((performance_now() * 1000.0) as u64)
+    }
+    #[cfg(not(feature = "wasm-bindgen"))]
+    pub fn now() -> Self {
+        extern "C" {
+            fn instant_now() -> u64;
+        }
+        Self(unsafe { instant_now() })
     }
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         Duration::from_micros(self.0 - earlier.0)


### PR DESCRIPTION
Trying to embed `biscuit-auth` compiled to wasm32 is a pain outside of JavaScript due to wasmbindgen.
It generates a lot of boilerplate, which is tedious and error-prone to mock correctly.
In this PR I propose to make the old `wasm` feature optional for the wasm32-unknown-unknown target and rename it `wasm-bindgen` to avoid confusion.
The only necessary import is for time, which is implemented through `performance_now` with wasmbindgen. I propose, for a pure wasm32 target, to create a simple `instant_now` symbol returning a u64, meant to represent a monotonic timestamp, and let the user provide the right implementation in their environment.

note: we could keep the name `wasm` for the feature making it a non breaking change, but I find it pretty confusing.