### PR TITLE
Compute variable shadow check with linear scan

### DIFF
--- a/biscuit-auth/src/datalog/expression.rs
+++ b/biscuit-auth/src/datalog/expression.rs
@@ -9,7 +9,7 @@ use super::{SymbolTable, TemporarySymbolTable};
 use regex::Regex;
 use std::sync::Arc;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     convert::TryFrom,
 };
 
@@ -625,13 +625,7 @@ impl Expression {
                         Some(StackElem::Closure(params, right_ops)),
                         Some(StackElem::Term(left_term)),
                     ) => {
-                        if values
-                            .keys()
-                            .collect::<HashSet<_>>()
-                            .intersection(&params.iter().collect())
-                            .next()
-                            .is_some()
-                        {
+                        if params.iter().any(|p| values.contains_key(p)) {
                             return Err(error::Expression::ShadowedVariable);
                         }
                         let mut values = values.clone();
@@ -648,13 +642,7 @@ impl Expression {
                         Some(StackElem::Term(right_term)),
                         Some(StackElem::Closure(params, left_ops)),
                     ) => {
-                        if values
-                            .keys()
-                            .collect::<HashSet<_>>()
-                            .intersection(&params.iter().collect())
-                            .next()
-                            .is_some()
-                        {
+                        if params.iter().any(|p| values.contains_key(p)) {
                             return Err(error::Expression::ShadowedVariable);
                         }
                         let mut values = values.clone();


### PR DESCRIPTION
Closure parameters will always be an extremely small N (usually one, sometimes two); constructing two HashSets and iterating the intersection is wasteful vs a linear scan over the closure parameters.