### PR TITLE
Resolve clippy and fmt issues

### DIFF
--- a/biscuit-auth/benches/token.rs
+++ b/biscuit-auth/benches/token.rs
@@ -72,7 +72,7 @@ fn append_block_2(b: &mut Bencher) {
     b.bytes = (data.len() - base_data.len()) as u64;
     assert_eq!(b.bytes, 189);
     b.iter(|| {
-        let token = Biscuit::from(&base_data, &root.public()).unwrap();
+        let token = Biscuit::from(&base_data, root.public()).unwrap();
         let block_builder = BlockBuilder::new()
             .check_resource("file1")
             .check_operation("read");
@@ -111,7 +111,7 @@ fn append_block_5(b: &mut Bencher) {
     b.bytes = (data.len() - base_data.len()) as u64;
     assert_eq!(b.bytes, 189);
     b.iter(|| {
-        let token2 = Biscuit::from(&data, &root.public()).unwrap();
+        let token2 = Biscuit::from(&data, root.public()).unwrap();
         let block_builder = BlockBuilder::new()
             .check_resource("file1")
             .check_operation("read");
@@ -121,7 +121,7 @@ fn append_block_5(b: &mut Bencher) {
             .unwrap();
         let data = token3.to_vec().unwrap();
 
-        let token3 = Biscuit::from(&data, &root.public()).unwrap();
+        let token3 = Biscuit::from(&data, root.public()).unwrap();
         let block_builder = BlockBuilder::new()
             .check_resource("file1")
             .check_operation("read");
@@ -131,7 +131,7 @@ fn append_block_5(b: &mut Bencher) {
             .unwrap();
         let data = token4.to_vec().unwrap();
 
-        let token4 = Biscuit::from(&data, &root.public()).unwrap();
+        let token4 = Biscuit::from(&data, root.public()).unwrap();
         let block_builder = BlockBuilder::new()
             .check_resource("file1")
             .check_operation("read");
@@ -265,7 +265,7 @@ fn verify_block_2(b: &mut Bencher) {
         token2.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -282,7 +282,7 @@ fn verify_block_2(b: &mut Bencher) {
         .unwrap();
     b.bytes = data.len() as u64;
     b.iter(|| {
-        let token = Biscuit::from(&data, &root.public()).unwrap();
+        let token = Biscuit::from(&data, root.public()).unwrap();
         let mut verifier = AuthorizerBuilder::new()
             .fact("resource(\"file1\")")
             .unwrap()
@@ -352,7 +352,7 @@ fn verify_block_5(b: &mut Bencher) {
         token5.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -370,7 +370,7 @@ fn verify_block_5(b: &mut Bencher) {
 
     b.bytes = data.len() as u64;
     b.iter(|| {
-        let token = Biscuit::from(&data, &root.public()).unwrap();
+        let token = Biscuit::from(&data, root.public()).unwrap();
         let mut verifier = AuthorizerBuilder::new()
             .fact("resource(\"file1\")")
             .unwrap()
@@ -413,7 +413,7 @@ fn check_signature_2(b: &mut Bencher) {
         token2.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -431,7 +431,7 @@ fn check_signature_2(b: &mut Bencher) {
 
     b.bytes = data.len() as u64;
     b.iter(|| {
-        let _token = Biscuit::from(&data, &root.public()).unwrap();
+        let _token = Biscuit::from(&data, root.public()).unwrap();
     });
 }
 
@@ -486,7 +486,7 @@ fn check_signature_5(b: &mut Bencher) {
         token5.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -504,7 +504,7 @@ fn check_signature_5(b: &mut Bencher) {
 
     b.bytes = data.len() as u64;
     b.iter(|| {
-        let _token = Biscuit::from(&data, &root.public()).unwrap();
+        let _token = Biscuit::from(&data, root.public()).unwrap();
     });
 }
 
@@ -533,7 +533,7 @@ fn checks_block_2(b: &mut Bencher) {
         token2.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -549,7 +549,7 @@ fn checks_block_2(b: &mut Bencher) {
         })
         .unwrap();
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     b.bytes = data.len() as u64;
     b.iter(|| {
         let mut verifier = AuthorizerBuilder::new()
@@ -594,7 +594,7 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
         token2.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -610,7 +610,7 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
         })
         .unwrap();
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     b.bytes = data.len() as u64;
     b.iter(|| {
         let _verifier = token.authorizer().unwrap();
@@ -642,7 +642,7 @@ fn checks_block_verify_only2(b: &mut Bencher) {
         token2.to_vec().unwrap()
     };
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
         .fact("resource(\"file1\")")
         .unwrap()
@@ -658,7 +658,7 @@ fn checks_block_verify_only2(b: &mut Bencher) {
         })
         .unwrap();
 
-    let token = Biscuit::from(&data, &root.public()).unwrap();
+    let token = Biscuit::from(&data, root.public()).unwrap();
     b.iter(|| {
         let mut verifier = AuthorizerBuilder::new()
             .fact("resource(\"file1\")")

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -49,7 +49,7 @@ fn main() {
         Some("--json") => json = true,
         Some("--key") => root_key = args.next(),
         Some(arg) => {
-            println!("unknown argument: {}", arg);
+            println!("unknown argument: {arg}");
             return;
         }
         None => {}
@@ -60,7 +60,7 @@ fn main() {
         Some("--json") => json = true,
         Some("--key") => root_key = args.next(),
         Some(arg) => {
-            println!("unknown argument: {}", arg);
+            println!("unknown argument: {arg}");
             return;
         }
         None => {}
@@ -71,7 +71,7 @@ fn main() {
         Some("--json") => json = true,
         Some("--key") => root_key = args.next(),
         Some(arg) => {
-            println!("unknown argument: {}", arg);
+            println!("unknown argument: {arg}");
             return;
         }
         None => {}
@@ -183,7 +183,7 @@ fn run(target: String, root_key: Option<String>, test: bool, json: bool) {
         })
         .unwrap();
 
-        println!("{}", s);
+        println!("{s}");
     } else {
         println!("# Biscuit samples and expected results\n");
         println!(
@@ -243,13 +243,13 @@ impl TestResult {
             if i == 0 {
                 writeln!(&mut s, "authority:");
             } else {
-                writeln!(&mut s, "{}:", i);
+                writeln!(&mut s, "{i}:");
             }
 
             writeln!(&mut s, "symbols: {:?}\n", block.symbols);
             writeln!(&mut s, "public keys: {:?}\n", block.public_keys);
             if let Some(key) = &block.external_key {
-                writeln!(&mut s, "external signature by: {:?}\n", key);
+                writeln!(&mut s, "external signature by: {key:?}\n");
             }
             writeln!(&mut s, "block version: {}\n", block.version);
             writeln!(&mut s, "```\n{}```\n", block.code);
@@ -259,7 +259,7 @@ impl TestResult {
             if name.is_empty() {
                 writeln!(&mut s, "### validation\n")
             } else {
-                writeln!(&mut s, "### validation for \"{}\"\n", name)
+                writeln!(&mut s, "### validation for \"{name}\"\n")
             };
 
             if let Some(world) = &validation.world {
@@ -271,7 +271,7 @@ impl TestResult {
 
                 writeln!(&mut s, "revocation ids:");
                 for id in &validation.revocation_ids {
-                    writeln!(&mut s, "- `{}`", id);
+                    writeln!(&mut s, "- `{id}`");
                 }
                 writeln!(&mut s, "\nauthorizer world:\n```\nWorld {{\n  facts: {:#?}\n  rules: {:#?}\n  checks: {:#?}\n  policies: {:#?}\n}}\n```\n",
                          world.facts, world.rules, world.checks, world.policies);
@@ -333,7 +333,7 @@ fn validate_token_with_limits_and_external_functions(
     run_limits: RunLimits,
     extern_funcs: HashMap<String, ExternFunc>,
 ) -> Validation {
-    let token = match Biscuit::from(&data[..], &root.public()) {
+    let token = match Biscuit::from(data, root.public()) {
         Ok(t) => t,
         Err(e) => {
             return Validation {
@@ -392,7 +392,7 @@ fn validate_token_with_limits_and_external_functions(
         let mut rules: Vec<String> = Vec::new();
         for rule in block.rules.iter() {
             let r =
-                convert::proto_rule_to_token_rule(&rule, snapshot.world.version.unwrap()).unwrap();
+                convert::proto_rule_to_token_rule(rule, snapshot.world.version.unwrap()).unwrap();
             rules.push(symbols.print_rule(&r.0));
         }
         if !rules.is_empty() {
@@ -405,7 +405,7 @@ fn validate_token_with_limits_and_external_functions(
 
         let mut checks = Vec::new();
         for check in block.checks.iter() {
-            let c = convert::proto_check_to_token_check(&check, snapshot.world.version.unwrap())
+            let c = convert::proto_check_to_token_check(check, snapshot.world.version.unwrap())
                 .unwrap();
             checks.push(symbols.print_check(&c));
         }
@@ -494,14 +494,14 @@ fn add_test_result(results: &mut Vec<TestResult>, mut testcase: TestResult) {
 fn write_testcase(target: &str, name: &str, data: &[u8]) {
     //println!("written to: {}/{}", target, name);
 
-    let mut file = File::create(&format!("{}/{}.bc", target, name)).unwrap();
+    let mut file = File::create(format!("{target}/{name}.bc")).unwrap();
     file.write_all(data).unwrap();
     file.flush().unwrap();
 }
 
 #[track_caller]
 fn load_testcase(target: &str, name: &str) -> Vec<u8> {
-    std::fs::read(&format!("{}/{}.bc", target, name)).unwrap()
+    std::fs::read(format!("{target}/{name}.bc")).unwrap()
 }
 
 fn print_diff(actual: &str, expected: &str) {
@@ -518,14 +518,14 @@ fn write_or_load_testcase(
     test: bool,
 ) -> Vec<u8> {
     if test {
-        let v = load_testcase(target, &filename);
+        let v = load_testcase(target, filename);
         if let Ok(expected) = Biscuit::from(&v[..], root.public()) {
             print_diff(&token.print(), &expected.print());
         }
         v
     } else {
         let data = token.to_vec().unwrap();
-        write_testcase(target, &filename, &data[..]);
+        write_testcase(target, filename, &data[..]);
 
         data
     }
@@ -535,7 +535,6 @@ fn basic_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "basic token".to_string();
     let filename = "test001_basic".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -544,7 +543,7 @@ fn basic_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file1", "write");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -559,7 +558,7 @@ fn basic_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
         )
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -589,7 +588,6 @@ fn different_root_key(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(5678);
     let title = "different root key".to_string();
     let filename = "test002_different_root_key".to_string();
-    let token;
 
     let root2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
 
@@ -613,7 +611,7 @@ fn different_root_key(target: &str, root: &KeyPair, test: bool) -> TestResult {
         )
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -642,7 +640,6 @@ fn invalid_signature_format(target: &str, root: &KeyPair, test: bool) -> TestRes
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "invalid signature format".to_string();
     let filename = "test003_invalid_signature_format".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -651,7 +648,7 @@ fn invalid_signature_format(target: &str, root: &KeyPair, test: bool) -> TestRes
         right("file1", "write");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -661,11 +658,10 @@ fn invalid_signature_format(target: &str, root: &KeyPair, test: bool) -> TestRes
             block!(r#"check if resource($0), operation("read"), right($0, "read")"#),
         )
         .unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = if test {
-        let v = load_testcase(target, &filename);
-        v
+        load_testcase(target, &filename)
     } else {
         let serialized = biscuit2.container();
         let mut proto = serialized.to_proto();
@@ -694,7 +690,6 @@ fn random_block(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "random block".to_string();
     let filename = "test004_random_block".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -703,7 +698,7 @@ fn random_block(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file1", "write");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -714,11 +709,10 @@ fn random_block(target: &str, root: &KeyPair, test: bool) -> TestResult {
         )
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = if test {
-        let v = load_testcase(target, &filename);
-        v
+        load_testcase(target, &filename)
     } else {
         let serialized = biscuit2.container();
         let mut proto = serialized.to_proto();
@@ -749,7 +743,6 @@ fn invalid_signature(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "invalid signature".to_string();
     let filename = "test005_invalid_signature".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -758,7 +751,7 @@ fn invalid_signature(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file1", "write");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -768,15 +761,14 @@ fn invalid_signature(target: &str, root: &KeyPair, test: bool) -> TestResult {
             block!(r#"check if resource($0), operation("read"), right($0, "read")"#),
         )
         .unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = if test {
-        let v = load_testcase(target, &filename);
-        v
+        load_testcase(target, &filename)
     } else {
         let serialized = biscuit2.container();
         let mut proto = serialized.to_proto();
-        proto.authority.signature[0] = proto.authority.signature[0] + 1;
+        proto.authority.signature[0] += 1;
         let mut data = Vec::new();
         proto.encode(&mut data).unwrap();
 
@@ -803,7 +795,6 @@ fn reordered_blocks(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "reordered blocks".to_string();
     let filename = "test006_reordered_blocks".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -812,7 +803,7 @@ fn reordered_blocks(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file1", "write");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -827,7 +818,7 @@ fn reordered_blocks(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let biscuit3 = biscuit2
         .append_with_keypair(&keypair3, block!(r#"check if resource("file1")"#))
         .unwrap();
-    token = print_blocks(&biscuit3);
+    let token = print_blocks(&biscuit3);
 
     let mut serialized = biscuit3.container().clone();
     let mut blocks = vec![];
@@ -836,8 +827,7 @@ fn reordered_blocks(target: &str, root: &KeyPair, test: bool) -> TestResult {
     serialized.blocks = blocks;
 
     let data = if test {
-        let v = load_testcase(target, &filename);
-        v
+        load_testcase(target, &filename)
     } else {
         let data = serialized.to_vec().unwrap();
         write_testcase(target, &filename, &data[..]);
@@ -862,7 +852,6 @@ fn scoped_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "scoped rules".to_string();
     let filename = "test007_scoped_rules".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -870,7 +859,7 @@ fn scoped_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
         owner("alice", "file1");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -892,7 +881,7 @@ fn scoped_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
 
     let keypair3 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let biscuit3 = biscuit2.append_with_keypair(&keypair3, block3).unwrap();
-    token = print_blocks(&biscuit3);
+    let token = print_blocks(&biscuit3);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit3, test);
 
@@ -922,14 +911,13 @@ fn scoped_checks(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "scoped checks".to_string();
     let filename = "test008_scoped_checks".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
         right("file1", "read");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -944,7 +932,7 @@ fn scoped_checks(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let biscuit3 = biscuit2
         .append_with_keypair(&keypair3, block!(r#"right("file2", "read")"#))
         .unwrap();
-    token = print_blocks(&biscuit3);
+    let token = print_blocks(&biscuit3);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit3, test);
 
@@ -974,11 +962,10 @@ fn expired_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "expired token".to_string();
     let filename = "test009_expired_token".to_string();
-    let token;
 
     let builder = Biscuit::builder();
     let biscuit1 = builder
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
 
     let block2 = block!(r#"check if resource("file1");"#)
@@ -991,7 +978,7 @@ fn expired_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1022,21 +1009,20 @@ fn authorizer_scope(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "authorizer scope".to_string();
     let filename = "test010_authorizer_scope".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
         right("file1", "read");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let biscuit2 = biscuit1
         .append_with_keypair(&keypair2, block!(r#"right("file2", "read")"#))
         .unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1067,16 +1053,15 @@ fn authorizer_authority_checks(target: &str, root: &KeyPair, test: bool) -> Test
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "authorizer authority checks".to_string();
     let filename = "test011_authorizer_authority_caveats".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
         right("file1", "read");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1107,12 +1092,11 @@ fn authority_checks(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "authority checks".to_string();
     let filename = "test012_authority_caveats".to_string();
-    let token;
 
     let biscuit1 = biscuit!(r#"check if resource("file1")"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1155,7 +1139,6 @@ fn block_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "block rules".to_string();
     let filename = "test013_block_rules".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -1163,7 +1146,7 @@ fn block_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file2", "read");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -1177,7 +1160,7 @@ fn block_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
         check if valid_date($0), resource($0);
     "#)).unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1220,12 +1203,11 @@ fn regex_constraint(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "regex_constraint".to_string();
     let filename = "test014_regex_constraint".to_string();
-    let token;
 
     let biscuit1 = biscuit!(r#"check if resource($0), $0.matches("file[0-9]+.txt")"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1251,12 +1233,11 @@ fn multi_queries_checks(target: &str, root: &KeyPair, test: bool) -> TestResult 
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "multi queries checks".to_string();
     let filename = "test015_multi_queries_caveats".to_string();
-    let token;
 
     let biscuit1 = biscuit!(r#"must_be_present("hello")"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1281,17 +1262,16 @@ fn check_head_name(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "check head name should be independent from fact names".to_string();
     let filename = "test016_caveat_head_name".to_string();
-    let token;
 
     let biscuit1 = biscuit!(r#"check if resource("hello")"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let biscuit2 = biscuit1
         .append_with_keypair(&keypair2, block!(r#"query("test")"#))
         .unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1312,7 +1292,6 @@ fn expressions(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test expression syntax and all available operations".to_string();
     let filename = "test017_expressions".to_string();
-    let token;
 
     let biscuit = biscuit!(r#"
         //boolean true
@@ -1390,9 +1369,9 @@ fn expressions(target: &str, root: &KeyPair, test: bool) -> TestResult {
         // empty set literal
         check if {,}.length() === 0;
     "#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -1414,10 +1393,9 @@ fn unbound_variables_in_rule(target: &str, root: &KeyPair, test: bool) -> TestRe
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "invalid block rule with unbound_variables".to_string();
     let filename = "test018_unbound_variables_in_rule".to_string();
-    let token;
 
     let biscuit1 = biscuit!(r#"check if operation("read")"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
 
     let block2 = BlockBuilder::new()
@@ -1431,7 +1409,7 @@ fn unbound_variables_in_rule(target: &str, root: &KeyPair, test: bool) -> TestRe
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1453,17 +1431,16 @@ fn generating_ambient_from_variables(target: &str, root: &KeyPair, test: bool) -
     let title = "invalid block rule generating an #authority or #ambient symbol with a variable"
         .to_string();
     let filename = "test019_generating_ambient_from_variables".to_string();
-    let token;
 
     let biscuit1 = biscuit!(r#"check if operation("read")"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let biscuit2 = biscuit1
         .append_with_keypair(&keypair2, block!(r#"operation("read") <- operation($any)"#))
         .unwrap();
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1484,7 +1461,6 @@ fn sealed_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "sealed token".to_string();
     let filename = "test020_sealed".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -1493,7 +1469,7 @@ fn sealed_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file1", "write");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -1504,7 +1480,7 @@ fn sealed_token(target: &str, root: &KeyPair, test: bool) -> TestResult {
         )
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = if test {
         let v = load_testcase(target, &filename);
@@ -1542,12 +1518,11 @@ fn parsing(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "parsing".to_string();
     let filename = "test021_parsing".to_string();
-    let token;
 
     let biscuit1 = biscuit!("ns::fact_123(\"hello é\t😁\")")
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1573,7 +1548,6 @@ fn default_symbols(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "default_symbols".to_string();
     let filename = "test022_default_symbols".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"read(0);write(1);resource(2);operation(3);right(4);time(5);
@@ -1582,9 +1556,9 @@ fn default_symbols(target: &str, root: &KeyPair, test: bool) -> TestResult {
     ip_address(17);client(18);client_ip(19);domain(20);path(21);
     version(22);cluster(23);node(24);hostname(25);nonce(26);query(27)"#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1617,10 +1591,9 @@ fn execution_scope(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "execution scope".to_string();
     let filename = "test023_execution_scope".to_string();
-    let token;
 
     let biscuit1 = biscuit!("authority_fact(1)")
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -1640,7 +1613,7 @@ fn execution_scope(target: &str, root: &KeyPair, test: bool) -> TestResult {
             ),
         )
         .unwrap();
-    token = print_blocks(&biscuit3);
+    let token = print_blocks(&biscuit3);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit3, test);
 
@@ -1662,7 +1635,6 @@ fn third_party(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "third party".to_string();
     let filename = "test024_third_party".to_string();
-    let token;
 
     // keep this to conserve the same RNG state
     let _ = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -1681,7 +1653,7 @@ fn third_party(target: &str, root: &KeyPair, test: bool) -> TestResult {
     "#,
         external_pub = external.public()
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let req = biscuit1.third_party_request().unwrap();
@@ -1702,7 +1674,7 @@ fn third_party(target: &str, root: &KeyPair, test: bool) -> TestResult {
         .append_third_party_with_keypair(external.public(), res, keypair2)
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -1724,7 +1696,6 @@ fn check_all(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "block rules".to_string();
     let filename = "test025_check_all".to_string();
-    let token;
 
     let biscuit1 = biscuit!(
         r#"
@@ -1732,10 +1703,10 @@ fn check_all(target: &str, root: &KeyPair, test: bool) -> TestResult {
         check all operation($op), allowed_operations($allowed), $allowed.contains($op);
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
-    token = print_blocks(&biscuit1);
+    let token = print_blocks(&biscuit1);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit1, test);
 
@@ -1789,7 +1760,6 @@ fn public_keys_interning(target: &str, root: &KeyPair, test: bool) -> TestResult
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "public keys interning".to_string();
     let filename = "test026_public_keys_interning".to_string();
-    let token;
 
     // keep this to conserve the same RNG state
     let _ = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -1825,7 +1795,7 @@ fn public_keys_interning(target: &str, root: &KeyPair, test: bool) -> TestResult
     "#,
         k1 = external1.public()
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
     let req1 = biscuit1.third_party_request().unwrap();
@@ -1917,7 +1887,7 @@ fn public_keys_interning(target: &str, root: &KeyPair, test: bool) -> TestResult
         )
         .unwrap();
 
-    token = print_blocks(&biscuit5);
+    let token = print_blocks(&biscuit5);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit5, test);
 
@@ -1953,7 +1923,6 @@ fn integer_wraparound(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "integer wraparound".to_string();
     let filename = "test027_integer_wraparound".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -1962,17 +1931,17 @@ fn integer_wraparound(target: &str, root: &KeyPair, test: bool) -> TestResult {
           check if -9223372036854775808 - 1 !== 0;
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
     let mut validations = BTreeMap::new();
     validations.insert(
         "".to_string(),
-        validate_token(root, &data[..], &format!(r#"allow if true;"#)),
+        validate_token(root, &data[..], r#"allow if true;"#),
     );
 
     TestResult {
@@ -1987,7 +1956,6 @@ fn expressions_v4(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test expression syntax and all available operations (v4 blocks)".to_string();
     let filename = "test028_expressions_v4".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -2007,9 +1975,9 @@ fn expressions_v4(target: &str, root: &KeyPair, test: bool) -> TestResult {
         check if {1, 4} !== {1, 2};
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2031,12 +1999,11 @@ fn reject_if(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test reject if".to_string();
     let filename = "test029_reject_if".to_string();
-    let token;
 
     let biscuit = biscuit!(r#"reject if test($test), $test"#)
-        .build_with_rng(&root, SymbolTable::default(), &mut rng)
+        .build_with_rng(root, SymbolTable::default(), &mut rng)
         .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2062,7 +2029,6 @@ fn null(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test null".to_string();
     let filename = "test030_null".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -2070,9 +2036,9 @@ fn null(target: &str, root: &KeyPair, test: bool) -> TestResult {
     reject if fact(null, $value), $value != null;
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2106,7 +2072,6 @@ fn heterogeneous_equal(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test heterogeneous equal".to_string();
     let filename = "test031_heterogeneous_equal".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -2133,9 +2098,9 @@ fn heterogeneous_equal(target: &str, root: &KeyPair, test: bool) -> TestResult {
     check if fact2(1, $value), 1 != $value;
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2165,7 +2130,6 @@ fn closures(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test laziness and closures".to_string();
     let filename = "test032_laziness_closures".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -2191,10 +2155,10 @@ fn closures(target: &str, root: &KeyPair, test: bool) -> TestResult {
         check if {1,2,3}.any($p -> $p > 1 && {3,4,5}.any($q -> $p == $q));
         "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2224,7 +2188,6 @@ fn type_of(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test .type()".to_string();
     let filename = "test033_typeof".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -2255,10 +2218,10 @@ fn type_of(target: &str, root: &KeyPair, test: bool) -> TestResult {
         check if map($t), $t.type() == "map";
         "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
 
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2280,7 +2243,6 @@ fn array_map(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test array and map operations".to_string();
     let filename = "test034_array_map".to_string();
-    let token;
 
     let biscuit = biscuit!(
         r#"
@@ -2316,9 +2278,9 @@ fn array_map(target: &str, root: &KeyPair, test: bool) -> TestResult {
         check if { "user": { "id": 1, "roles": ["admin"] } }.get("user").get("roles").contains("admin");
     "#
     )
-    .build_with_rng(&root, SymbolTable::default(), &mut rng)
+    .build_with_rng(root, SymbolTable::default(), &mut rng)
     .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2340,13 +2302,12 @@ fn ffi(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "test ffi calls (v6 blocks)".to_string();
     let filename = "test035_ffi".to_string();
-    let token;
 
     let biscuit =
         biscuit!(r#"check if true.extern::test(), "a".extern::test("a") == "equal strings""#)
-            .build_with_rng(&root, SymbolTable::default(), &mut rng)
+            .build_with_rng(root, SymbolTable::default(), &mut rng)
             .unwrap();
-    token = print_blocks(&biscuit);
+    let token = print_blocks(&biscuit);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit, test);
 
@@ -2388,7 +2349,6 @@ fn secp256r1(target: &str, root: &KeyPair, test: bool) -> TestResult {
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "ECDSA secp256r1 signatures".to_string();
     let filename = "test036_secp256r1".to_string();
-    let token;
 
     let keypair2 = KeyPair::new_with_rng(Algorithm::Secp256r1, &mut rng);
     let biscuit1 = biscuit!(
@@ -2398,7 +2358,7 @@ fn secp256r1(target: &str, root: &KeyPair, test: bool) -> TestResult {
         right("file1", "write");
     "#
     )
-    .build_with_key_pair(&root, SymbolTable::default(), &keypair2)
+    .build_with_key_pair(root, SymbolTable::default(), &keypair2)
     .unwrap();
 
     let keypair3 = KeyPair::new_with_rng(Algorithm::Secp256r1, &mut rng);
@@ -2413,7 +2373,7 @@ fn secp256r1(target: &str, root: &KeyPair, test: bool) -> TestResult {
         )
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 
@@ -2443,7 +2403,6 @@ fn secp256r1_third_party(target: &str, root: &KeyPair, test: bool) -> TestResult
     let mut rng: StdRng = SeedableRng::seed_from_u64(1234);
     let title = "ECDSA secp256r1 signature on third-party block".to_string();
     let filename = "test037_secp256r1_third_party".to_string();
-    let token;
 
     let external_keypair = KeyPair::new_with_rng(Algorithm::Secp256r1, &mut rng);
     let keypair2 = KeyPair::new_with_rng(Algorithm::Secp256r1, &mut rng);
@@ -2456,7 +2415,7 @@ fn secp256r1_third_party(target: &str, root: &KeyPair, test: bool) -> TestResult
     "#,
         external_pub = external_keypair.public(),
     )
-    .build_with_key_pair(&root, SymbolTable::default(), &keypair2)
+    .build_with_key_pair(root, SymbolTable::default(), &keypair2)
     .unwrap();
 
     let req = biscuit1.third_party_request().unwrap();
@@ -2474,7 +2433,7 @@ fn secp256r1_third_party(target: &str, root: &KeyPair, test: bool) -> TestResult
         .append_third_party_with_keypair(external_keypair.public(), block, keypair3)
         .unwrap();
 
-    token = print_blocks(&biscuit2);
+    let token = print_blocks(&biscuit2);
 
     let data = write_or_load_testcase(target, &filename, root, &biscuit2, test);
 

--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -26,7 +26,7 @@ fn main() {
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
 
-    println!("biscuit1: {}", biscuit1);
+    println!("biscuit1: {biscuit1}");
 
     let serialized_req = biscuit1.third_party_request().unwrap().serialize().unwrap();
 
@@ -38,7 +38,7 @@ fn main() {
 
     let biscuit2 = biscuit1.append_third_party(external.public(), res).unwrap();
 
-    println!("biscuit2: {}", biscuit2);
+    println!("biscuit2: {biscuit2}");
 
     let mut authorizer = AuthorizerBuilder::new()
         .allow_all()

--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -27,7 +27,7 @@ fn main() {
     for i in 0..token.block_count() {
         println!("block {}:\n{}\n", i, token.print_block_source(i).unwrap());
     }
-    println!("token:\n{}", token);
+    println!("token:\n{token}");
 
     let mut authorizer = AuthorizerBuilder::new().allow_all().build(&token).unwrap();
 

--- a/biscuit-auth/src/crypto/ed25519.rs
+++ b/biscuit-auth/src/crypto/ed25519.rs
@@ -59,7 +59,7 @@ impl KeyPair {
     pub fn sign(&self, data: &[u8]) -> Result<Signature, error::Format> {
         Ok(Signature(
             self.kp
-                .try_sign(&data)
+                .try_sign(data)
                 .map_err(|s| s.to_string())
                 .map_err(error::Signature::InvalidSignatureGeneration)
                 .map_err(error::Format::Signature)?
@@ -210,6 +210,7 @@ impl Drop for PrivateKey {
 #[derive(Debug, Clone, Copy, Eq)]
 pub struct PublicKey(ed25519_dalek::VerifyingKey);
 
+#[allow(clippy::wrong_self_convention)]
 impl PublicKey {
     /// serializes to a byte array
     pub fn to_bytes(&self) -> [u8; 32] {
@@ -264,14 +265,13 @@ impl PublicKey {
     ) -> Result<(), error::Format> {
         let signature_bytes: [u8; 64] = signature.0.clone().try_into().map_err(|e| {
             error::Format::BlockSignatureDeserializationError(format!(
-                "block signature deserialization error: {:?}",
-                e
+                "block signature deserialization error: {e:?}"
             ))
         })?;
         let sig = ed25519_dalek::Signature::from_bytes(&signature_bytes);
 
         self.0
-            .verify_strict(&data, &sig)
+            .verify_strict(data, &sig)
             .map_err(|s| s.to_string())
             .map_err(error::Signature::InvalidSignature)
             .map_err(error::Format::Signature)
@@ -321,11 +321,11 @@ impl PublicKey {
     }
 
     pub(crate) fn write(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ed25519/{}", hex::encode(&self.to_bytes()))
+        write!(f, "ed25519/{}", hex::encode(self.to_bytes()))
     }
 
     pub fn print(&self) -> String {
-        format!("ed25519/{}", hex::encode(&self.to_bytes()))
+        format!("ed25519/{}", hex::encode(self.to_bytes()))
     }
 }
 

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -490,12 +490,11 @@ pub fn sign_authority_block(
     version: u32,
 ) -> Result<Signature, error::Token> {
     let to_sign = match version {
-        0 => generate_authority_block_signature_payload_v0(&message, &next_key.public()),
-        1 => generate_authority_block_signature_payload_v1(&message, &next_key.public(), version),
+        0 => generate_authority_block_signature_payload_v0(message, &next_key.public()),
+        1 => generate_authority_block_signature_payload_v1(message, &next_key.public(), version),
         _ => {
             return Err(error::Format::DeserializationError(format!(
-                "unsupported block version: {}",
-                version
+                "unsupported block version: {version}"
             ))
             .into())
         }
@@ -515,9 +514,9 @@ pub fn sign_block(
     version: u32,
 ) -> Result<Signature, error::Token> {
     let to_sign = match version {
-        0 => generate_block_signature_payload_v0(&message, &next_key.public(), external_signature),
+        0 => generate_block_signature_payload_v0(message, &next_key.public(), external_signature),
         1 => generate_block_signature_payload_v1(
-            &message,
+            message,
             &next_key.public(),
             external_signature,
             previous_signature,
@@ -525,8 +524,7 @@ pub fn sign_block(
         ),
         _ => {
             return Err(error::Format::DeserializationError(format!(
-                "unsupported block version: {}",
-                version
+                "unsupported block version: {version}"
             ))
             .into())
         }
@@ -645,7 +643,7 @@ pub(crate) fn generate_block_signature_payload_v0(
     let mut to_verify = payload.to_vec();
 
     if let Some(signature) = external_signature.as_ref() {
-        to_verify.extend_from_slice(&signature.signature.to_bytes());
+        to_verify.extend_from_slice(signature.signature.to_bytes());
     }
     to_verify.extend(&(next_key.algorithm() as i32).to_le_bytes());
     to_verify.extend(next_key.to_bytes());
@@ -696,7 +694,7 @@ pub(crate) fn generate_block_signature_payload_v1(
 
     if let Some(signature) = external_signature.as_ref() {
         to_verify.extend(b"\0EXTERNALSIG\0");
-        to_verify.extend_from_slice(&signature.signature.to_bytes());
+        to_verify.extend_from_slice(signature.signature.to_bytes());
     }
 
     to_verify

--- a/biscuit-auth/src/crypto/p256.rs
+++ b/biscuit-auth/src/crypto/p256.rs
@@ -51,7 +51,7 @@ impl KeyPair {
     pub fn sign(&self, data: &[u8]) -> Result<Signature, error::Format> {
         let signature: ecdsa::Signature<NistP256> = self
             .kp
-            .try_sign(&data)
+            .try_sign(data)
             .map_err(|s| s.to_string())
             .map_err(error::Signature::InvalidSignatureGeneration)
             .map_err(error::Format::Signature)?;
@@ -192,7 +192,7 @@ impl PrivateKey {
 
     /// returns the matching public key
     pub fn public(&self) -> PublicKey {
-        PublicKey(*(&self.0).verifying_key())
+        PublicKey(*self.0.verifying_key())
     }
 
     pub fn algorithm(&self) -> crate::format::schema::public_key::Algorithm {
@@ -210,6 +210,7 @@ impl std::clone::Clone for PrivateKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PublicKey(VerifyingKey);
 
+#[allow(clippy::wrong_self_convention)]
 impl PublicKey {
     /// serializes to a byte array
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -227,7 +228,7 @@ impl PublicKey {
             .map_err(|s| s.to_string())
             .map_err(Format::InvalidKey)?;
 
-        Ok(Self(k.into()))
+        Ok(Self(k))
     }
 
     /// deserializes from an hex-encoded string
@@ -300,13 +301,12 @@ impl PublicKey {
     ) -> Result<(), error::Format> {
         let sig = p256::ecdsa::Signature::from_der(&signature.0).map_err(|e| {
             error::Format::BlockSignatureDeserializationError(format!(
-                "block signature deserialization error: {:?}",
-                e
+                "block signature deserialization error: {e:?}"
             ))
         })?;
 
         self.0
-            .verify(&data, &sig)
+            .verify(data, &sig)
             .map_err(|s| s.to_string())
             .map_err(error::Signature::InvalidSignature)
             .map_err(error::Format::Signature)
@@ -317,10 +317,10 @@ impl PublicKey {
     }
 
     pub(crate) fn write(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "secp256r1/{}", hex::encode(&self.to_bytes()))
+        write!(f, "secp256r1/{}", hex::encode(self.to_bytes()))
     }
     pub fn print(&self) -> String {
-        format!("secp256r1/{}", hex::encode(&self.to_bytes()))
+        format!("secp256r1/{}", hex::encode(self.to_bytes()))
     }
 }
 

--- a/biscuit-auth/src/datalog/expression.rs
+++ b/biscuit-auth/src/datalog/expression.rs
@@ -131,10 +131,10 @@ impl Unary {
 
     pub fn print(&self, value: String, symbols: &SymbolTable) -> String {
         match self {
-            Unary::Negate => format!("!{}", value),
-            Unary::Parens => format!("({})", value),
-            Unary::Length => format!("{}.length()", value),
-            Unary::TypeOf => format!("{}.type()", value),
+            Unary::Negate => format!("!{value}"),
+            Unary::Parens => format!("({value})"),
+            Unary::Length => format!("{value}.length()"),
+            Unary::TypeOf => format!("{value}.type()"),
             Unary::Ffi(name) => {
                 format!("{value}.extern::{}()", symbols.print_symbol_default(*name))
             }
@@ -385,7 +385,7 @@ impl Binary {
             (Binary::Add, Term::Str(s1), Term::Str(s2)) => {
                 match (symbols.get_symbol(s1), symbols.get_symbol(s2)) {
                     (Some(s1), Some(s2)) => {
-                        let s = format!("{}{}", s1, s2);
+                        let s = format!("{s1}{s2}");
                         let sym = symbols.insert(&s);
                         Ok(Term::Str(sym))
                     }
@@ -539,29 +539,29 @@ impl Binary {
 
     pub fn print(&self, left: String, right: String, symbols: &SymbolTable) -> String {
         match self {
-            Binary::LessThan => format!("{} < {}", left, right),
-            Binary::GreaterThan => format!("{} > {}", left, right),
-            Binary::LessOrEqual => format!("{} <= {}", left, right),
-            Binary::GreaterOrEqual => format!("{} >= {}", left, right),
-            Binary::Equal => format!("{} === {}", left, right),
-            Binary::HeterogeneousEqual => format!("{} == {}", left, right),
-            Binary::NotEqual => format!("{} !== {}", left, right),
-            Binary::HeterogeneousNotEqual => format!("{} != {}", left, right),
-            Binary::Contains => format!("{}.contains({})", left, right),
-            Binary::Prefix => format!("{}.starts_with({})", left, right),
-            Binary::Suffix => format!("{}.ends_with({})", left, right),
-            Binary::Regex => format!("{}.matches({})", left, right),
-            Binary::Add => format!("{} + {}", left, right),
-            Binary::Sub => format!("{} - {}", left, right),
-            Binary::Mul => format!("{} * {}", left, right),
-            Binary::Div => format!("{} / {}", left, right),
-            Binary::And => format!("{} &&! {}", left, right),
-            Binary::Or => format!("{} ||! {}", left, right),
-            Binary::Intersection => format!("{}.intersection({})", left, right),
-            Binary::Union => format!("{}.union({})", left, right),
-            Binary::BitwiseAnd => format!("{} & {}", left, right),
-            Binary::BitwiseOr => format!("{} | {}", left, right),
-            Binary::BitwiseXor => format!("{} ^ {}", left, right),
+            Binary::LessThan => format!("{left} < {right}"),
+            Binary::GreaterThan => format!("{left} > {right}"),
+            Binary::LessOrEqual => format!("{left} <= {right}"),
+            Binary::GreaterOrEqual => format!("{left} >= {right}"),
+            Binary::Equal => format!("{left} === {right}"),
+            Binary::HeterogeneousEqual => format!("{left} == {right}"),
+            Binary::NotEqual => format!("{left} !== {right}"),
+            Binary::HeterogeneousNotEqual => format!("{left} != {right}"),
+            Binary::Contains => format!("{left}.contains({right})"),
+            Binary::Prefix => format!("{left}.starts_with({right})"),
+            Binary::Suffix => format!("{left}.ends_with({right})"),
+            Binary::Regex => format!("{left}.matches({right})"),
+            Binary::Add => format!("{left} + {right}"),
+            Binary::Sub => format!("{left} - {right}"),
+            Binary::Mul => format!("{left} * {right}"),
+            Binary::Div => format!("{left} / {right}"),
+            Binary::And => format!("{left} &&! {right}"),
+            Binary::Or => format!("{left} ||! {right}"),
+            Binary::Intersection => format!("{left}.intersection({right})"),
+            Binary::Union => format!("{left}.union({right})"),
+            Binary::BitwiseAnd => format!("{left} & {right}"),
+            Binary::BitwiseOr => format!("{left} | {right}"),
+            Binary::BitwiseXor => format!("{left} ^ {right}"),
             Binary::LazyAnd => format!("{left} && {right}"),
             Binary::LazyOr => format!("{left} || {right}"),
             Binary::All => format!("{left}.all({right})"),
@@ -757,7 +757,7 @@ mod tests {
 
         let values: HashMap<u32, Term> = [(2, Term::Integer(0))].iter().cloned().collect();
 
-        println!("ops: {:?}", ops);
+        println!("ops: {ops:?}");
 
         let e = Expression { ops };
         println!("print: {}", e.print(&symbols).unwrap());
@@ -787,7 +787,7 @@ mod tests {
                 Op::Binary(op),
             ];
 
-            println!("ops: {:?}", ops);
+            println!("ops: {ops:?}");
 
             let e = Expression { ops };
             println!("print: {}", e.print(&symbols).unwrap());
@@ -875,9 +875,9 @@ mod tests {
             Op::Binary(Binary::LessThan),
         ];
 
-        println!("ops1: {:?}", ops1);
-        println!("ops2: {:?}", ops2);
-        println!("ops3: {:?}", ops3);
+        println!("ops1: {ops1:?}");
+        println!("ops2: {ops2:?}");
+        println!("ops3: {ops3:?}");
         let e1 = Expression { ops: ops1 };
         let e2 = Expression { ops: ops2 };
         let e3 = Expression { ops: ops3 };
@@ -904,7 +904,7 @@ mod tests {
         for op in operators {
             let mut ops = operands.clone();
             ops.push(op);
-            println!("ops: {:?}", ops);
+            println!("ops: {ops:?}");
 
             let e = Expression { ops };
             println!("print: {}", e.print(&symbols).unwrap());
@@ -928,7 +928,7 @@ mod tests {
         for op in operators {
             let mut ops = operands.clone();
             ops.push(op);
-            println!("ops: {:?}", ops);
+            println!("ops: {ops:?}");
 
             let e = Expression { ops };
             println!("print: {}", e.print(&symbols).unwrap());
@@ -952,7 +952,7 @@ mod tests {
         for (op, result) in operators {
             let mut ops = operands.clone();
             ops.push(op);
-            println!("ops: {:?}", ops);
+            println!("ops: {ops:?}");
 
             let e = Expression { ops };
             println!("print: {}", e.print(&symbols).unwrap());
@@ -996,7 +996,7 @@ mod tests {
                 for (op, result) in &operators {
                     let mut ops = operand.clone();
                     ops.push(op.clone());
-                    println!("ops: {:?}", ops);
+                    println!("ops: {ops:?}");
 
                     let e = Expression { ops };
                     println!("print: {}", e.print(&symbols).unwrap());
@@ -1035,7 +1035,7 @@ mod tests {
                 for op in &operators {
                     let mut ops = operand.clone();
                     ops.push(op.clone());
-                    println!("ops: {:?}", ops);
+                    println!("ops: {ops:?}");
 
                     let e = Expression { ops };
                     println!("print: {}", e.print(&symbols).unwrap());

--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -324,6 +324,7 @@ impl Rule {
 }
 
 /// recursive iterator for rule application
+#[allow(clippy::type_complexity)]
 pub struct CombineIt<'a, IT> {
     variables: MatchedVariables,
     predicates: &'a [Predicate],
@@ -1053,10 +1054,10 @@ mod tests {
             ],
         );
 
-        println!("symbols: {:?}", syms);
+        println!("symbols: {syms:?}");
         println!("testing r1: {}", syms.print_rule(&r1));
         let query_rule_result = w.query_rule(r1, 0, &[0].iter().collect(), &syms);
-        println!("grandparents query_rules: {:?}", query_rule_result);
+        println!("grandparents query_rules: {query_rule_result:?}");
         println!("current facts: {:?}", w.facts);
 
         let r2 = rule(
@@ -1153,7 +1154,7 @@ mod tests {
                 &syms,
             )
             .unwrap();
-        println!("grandparents after inserting parent(C, E): {:?}", res);
+        println!("grandparents after inserting parent(C, E): {res:?}");
 
         let res = res
             .iter_all()
@@ -1360,7 +1361,7 @@ mod tests {
                 ),
                 0,
                 &[0].iter().collect(),
-                &syms,
+                syms,
             )
             .unwrap()
             .iter_all()
@@ -1401,11 +1402,11 @@ mod tests {
         let mut syms = SymbolTable::new();
 
         let t1 = SystemTime::now();
-        println!("t1 = {:?}", t1);
+        println!("t1 = {t1:?}");
         let t2 = t1 + Duration::from_secs(10);
-        println!("t2 = {:?}", t2);
+        println!("t2 = {t2:?}");
         let t3 = t2 + Duration::from_secs(30);
-        println!("t3 = {:?}", t3);
+        println!("t3 = {t3:?}");
 
         let t2_timestamp = t2.duration_since(UNIX_EPOCH).unwrap().as_secs();
 
@@ -1758,7 +1759,7 @@ mod tests {
             .map(|(_, fact)| fact)
             .cloned()
             .collect::<HashSet<_>>();
-        println!("got res: {:?}", res2);
+        println!("got res: {res2:?}");
         let compared = (vec![fact(less_than, &[&int(0), &def])])
             .drain(..)
             .collect::<HashSet<_>>();
@@ -1794,7 +1795,7 @@ mod tests {
             println!("\t{}", syms.print_fact(fact));
         }
 
-        assert!(res.len() == 0);
+        assert!(res.is_empty());
 
         // operation($unbound, "read") should not have been generated
         // in case it is generated though, verify that rule application

--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -86,6 +86,7 @@ impl Display for Origin {
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TrustedOrigins(Origin);
 
+#[allow(clippy::should_implement_trait)]
 impl TrustedOrigins {
     pub fn default() -> TrustedOrigins {
         let mut origins = Origin::default();

--- a/biscuit-auth/src/datalog/symbol.rs
+++ b/biscuit-auth/src/datalog/symbol.rs
@@ -163,7 +163,7 @@ impl SymbolTable {
     pub fn print_symbol_default(&self, i: SymbolIndex) -> String {
         self.get_symbol(i)
             .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("<{}?>", i))
+            .unwrap_or_else(|| format!("<{i}?>"))
     }
 
     pub fn print_world(&self, w: &World) -> String {
@@ -181,7 +181,7 @@ impl SymbolTable {
             .flat_map(|rules| rules.1.iter())
             .map(|(_, r)| self.print_rule(r))
             .collect::<Vec<_>>();
-        format!("World {{\n  facts: {:#?}\n  rules: {:#?}\n}}", facts, rules)
+        format!("World {{\n  facts: {facts:#?}\n  rules: {rules:#?}\n}}")
     }
 
     pub fn print_term(&self, term: &Term) -> String {
@@ -230,7 +230,7 @@ impl SymbolTable {
                         crate::datalog::MapKey::Str(s) => {
                             format!(
                                 "\"{}\": {}",
-                                self.print_symbol_default(*s as u64),
+                                self.print_symbol_default(*s),
                                 self.print_term(term)
                             )
                         }

--- a/biscuit-auth/src/error.rs
+++ b/biscuit-auth/src/error.rs
@@ -98,11 +98,11 @@ impl std::fmt::Display for Base64Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             Base64Error::InvalidByte(index, byte) => {
-                write!(f, "Invalid byte {}, offset {}.", byte, index)
+                write!(f, "Invalid byte {byte}, offset {index}.")
             }
             Base64Error::InvalidLength => write!(f, "Encoded text cannot have a 6-bit remainder."),
             Base64Error::InvalidLastSymbol(index, byte) => {
-                write!(f, "Invalid last symbol {}, offset {}.", byte, index)
+                write!(f, "Invalid last symbol {byte}, offset {index}.")
             }
         }
     }

--- a/biscuit-auth/src/format/convert.rs
+++ b/biscuit-auth/src/format/convert.rs
@@ -618,7 +618,7 @@ pub fn proto_id_to_token_term(input: &schema::Term) -> Result<Term, error::Forma
                     }
                 };
 
-                map.insert(key, proto_id_to_token_term(&value)?);
+                map.insert(key, proto_id_to_token_term(value)?);
             }
 
             Ok(Term::Map(map))
@@ -841,8 +841,7 @@ pub fn proto_scope_to_token_scope(input: &schema::Scope) -> Result<Scope, error:
                     Ok(Scope::Previous)
                 } else {
                     Err(error::Format::DeserializationError(format!(
-                        "deserialization error: unexpected value `{}` for scope type",
-                        i
+                        "deserialization error: unexpected value `{i}` for scope type"
                     )))
                 }
             }

--- a/biscuit-auth/src/format/mod.rs
+++ b/biscuit-auth/src/format/mod.rs
@@ -81,7 +81,7 @@ impl SerializedBiscuit {
         verification_mode: ThirdPartyVerificationMode,
     ) -> Result<Self, error::Format> {
         let data = schema::Biscuit::decode(slice).map_err(|e| {
-            error::Format::DeserializationError(format!("deserialization error: {:?}", e))
+            error::Format::DeserializationError(format!("deserialization error: {e:?}"))
         })?;
 
         let next_key = PublicKey::from_proto(&data.authority.next_key)?;
@@ -179,8 +179,7 @@ impl SerializedBiscuit {
 
         let authority = schema::Block::decode(&self.authority.data[..]).map_err(|e| {
             error::Token::Format(error::Format::BlockDeserializationError(format!(
-                "error deserializing authority block: {:?}",
-                e
+                "error deserializing authority block: {e:?}"
             )))
         })?;
 
@@ -200,8 +199,7 @@ impl SerializedBiscuit {
         for block in self.blocks.iter() {
             let deser = schema::Block::decode(&block.data[..]).map_err(|e| {
                 error::Token::Format(error::Format::BlockDeserializationError(format!(
-                    "error deserializing block: {:?}",
-                    e
+                    "error deserializing block: {e:?}"
                 )))
             })?;
 
@@ -288,7 +286,7 @@ impl SerializedBiscuit {
 
         b.encode(&mut v)
             .map(|_| v)
-            .map_err(|e| error::Format::SerializationError(format!("serialization error: {:?}", e)))
+            .map_err(|e| error::Format::SerializationError(format!("serialization error: {e:?}")))
     }
 
     /// creates a new token
@@ -326,7 +324,7 @@ impl SerializedBiscuit {
         token_block_to_proto_block(authority)
             .encode(&mut v)
             .map_err(|e| {
-                error::Format::SerializationError(format!("serialization error: {:?}", e))
+                error::Format::SerializationError(format!("serialization error: {e:?}"))
             })?;
 
         let signature = crypto::sign_authority_block(
@@ -363,7 +361,7 @@ impl SerializedBiscuit {
         token_block_to_proto_block(block)
             .encode(&mut v)
             .map_err(|e| {
-                error::Format::SerializationError(format!("serialization error: {:?}", e))
+                error::Format::SerializationError(format!("serialization error: {e:?}"))
             })?;
 
         let signature_version = block_signature_version(
@@ -509,7 +507,7 @@ impl SerializedBiscuit {
 
                 let to_verify = crypto::generate_seal_signature_payload_v0(block);
 
-                current_pub.verify_signature(&to_verify, &signature)?;
+                current_pub.verify_signature(&to_verify, signature)?;
             }
         }
 
@@ -600,13 +598,13 @@ mod tests {
             Err(_) => return,
         };
         prost_build::compile_protos(&["src/format/schema.proto"], &["src/"]).unwrap();
-        let mut file = std::fs::File::open(&format!("{out_dir}/biscuit.format.schema.rs")).unwrap();
+        let mut file = std::fs::File::open(format!("{out_dir}/biscuit.format.schema.rs")).unwrap();
         let mut contents = String::new();
         file.read_to_string(&mut contents).unwrap();
 
         let commited_schema = include_str!("schema.rs");
 
-        if &contents != commited_schema {
+        if contents != commited_schema {
             println!(
                 "{}",
                 colored_diff::PrettyDifference {

--- a/biscuit-auth/src/format/schema.rs
+++ b/biscuit-auth/src/format/schema.rs
@@ -1,39 +1,39 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Biscuit {
-    #[prost(uint32, optional, tag = "1")]
+    #[prost(uint32, optional, tag="1")]
     pub root_key_id: ::core::option::Option<u32>,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub authority: SignedBlock,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub blocks: ::prost::alloc::vec::Vec<SignedBlock>,
-    #[prost(message, required, tag = "4")]
+    #[prost(message, required, tag="4")]
     pub proof: Proof,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedBlock {
-    #[prost(bytes = "vec", required, tag = "1")]
+    #[prost(bytes="vec", required, tag="1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub next_key: PublicKey,
-    #[prost(bytes = "vec", required, tag = "3")]
+    #[prost(bytes="vec", required, tag="3")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag="4")]
     pub external_signature: ::core::option::Option<ExternalSignature>,
-    #[prost(uint32, optional, tag = "5")]
+    #[prost(uint32, optional, tag="5")]
     pub version: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExternalSignature {
-    #[prost(bytes = "vec", required, tag = "1")]
+    #[prost(bytes="vec", required, tag="1")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub public_key: PublicKey,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublicKey {
-    #[prost(enumeration = "public_key::Algorithm", required, tag = "1")]
+    #[prost(enumeration="public_key::Algorithm", required, tag="1")]
     pub algorithm: i32,
-    #[prost(bytes = "vec", required, tag = "2")]
+    #[prost(bytes="vec", required, tag="2")]
     pub key: ::prost::alloc::vec::Vec<u8>,
 }
 /// Nested message and enum types in `PublicKey`.
@@ -47,41 +47,41 @@ pub mod public_key {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
-    #[prost(oneof = "proof::Content", tags = "1, 2")]
+    #[prost(oneof="proof::Content", tags="1, 2")]
     pub content: ::core::option::Option<proof::Content>,
 }
 /// Nested message and enum types in `Proof`.
 pub mod proof {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(bytes, tag = "1")]
+        #[prost(bytes, tag="1")]
         NextSecret(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag = "2")]
+        #[prost(bytes, tag="2")]
         FinalSignature(::prost::alloc::vec::Vec<u8>),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Block {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "2")]
+    #[prost(string, optional, tag="2")]
     pub context: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag = "3")]
+    #[prost(uint32, optional, tag="3")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag = "5")]
+    #[prost(message, repeated, tag="5")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag = "6")]
+    #[prost(message, repeated, tag="6")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag = "7")]
+    #[prost(message, repeated, tag="7")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
-    #[prost(message, repeated, tag = "8")]
+    #[prost(message, repeated, tag="8")]
     pub public_keys: ::prost::alloc::vec::Vec<PublicKey>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Scope {
-    #[prost(oneof = "scope::Content", tags = "1, 2")]
+    #[prost(oneof="scope::Content", tags="1, 2")]
     pub content: ::core::option::Option<scope::Content>,
 }
 /// Nested message and enum types in `Scope`.
@@ -94,33 +94,33 @@ pub mod scope {
     }
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(enumeration = "ScopeType", tag = "1")]
+        #[prost(enumeration="ScopeType", tag="1")]
         ScopeType(i32),
-        #[prost(int64, tag = "2")]
+        #[prost(int64, tag="2")]
         PublicKey(i64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fact {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub predicate: Predicate,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Rule {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub head: Predicate,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub body: ::prost::alloc::vec::Vec<Predicate>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub expressions: ::prost::alloc::vec::Vec<Expression>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Check {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub queries: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(enumeration = "check::Kind", optional, tag = "2")]
+    #[prost(enumeration="check::Kind", optional, tag="2")]
     pub kind: ::core::option::Option<i32>,
 }
 /// Nested message and enum types in `Check`.
@@ -135,108 +135,108 @@ pub mod check {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Predicate {
-    #[prost(uint64, required, tag = "1")]
+    #[prost(uint64, required, tag="1")]
     pub name: u64,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub terms: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Term {
-    #[prost(oneof = "term::Content", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof="term::Content", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub content: ::core::option::Option<term::Content>,
 }
 /// Nested message and enum types in `Term`.
 pub mod term {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(uint32, tag = "1")]
+        #[prost(uint32, tag="1")]
         Variable(u32),
-        #[prost(int64, tag = "2")]
+        #[prost(int64, tag="2")]
         Integer(i64),
-        #[prost(uint64, tag = "3")]
+        #[prost(uint64, tag="3")]
         String(u64),
-        #[prost(uint64, tag = "4")]
+        #[prost(uint64, tag="4")]
         Date(u64),
-        #[prost(bytes, tag = "5")]
+        #[prost(bytes, tag="5")]
         Bytes(::prost::alloc::vec::Vec<u8>),
-        #[prost(bool, tag = "6")]
+        #[prost(bool, tag="6")]
         Bool(bool),
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         Set(super::TermSet),
-        #[prost(message, tag = "8")]
+        #[prost(message, tag="8")]
         Null(super::Empty),
-        #[prost(message, tag = "9")]
+        #[prost(message, tag="9")]
         Array(super::Array),
-        #[prost(message, tag = "10")]
+        #[prost(message, tag="10")]
         Map(super::Map),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TermSet {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub set: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Array {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub array: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Map {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub entries: ::prost::alloc::vec::Vec<MapEntry>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapEntry {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub key: MapKey,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub value: Term,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapKey {
-    #[prost(oneof = "map_key::Content", tags = "1, 2")]
+    #[prost(oneof="map_key::Content", tags="1, 2")]
     pub content: ::core::option::Option<map_key::Content>,
 }
 /// Nested message and enum types in `MapKey`.
 pub mod map_key {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(int64, tag = "1")]
+        #[prost(int64, tag="1")]
         Integer(i64),
-        #[prost(uint64, tag = "2")]
+        #[prost(uint64, tag="2")]
         String(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Expression {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Op {
-    #[prost(oneof = "op::Content", tags = "1, 2, 3, 4")]
+    #[prost(oneof="op::Content", tags="1, 2, 3, 4")]
     pub content: ::core::option::Option<op::Content>,
 }
 /// Nested message and enum types in `Op`.
 pub mod op {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(message, tag = "1")]
+        #[prost(message, tag="1")]
         Value(super::Term),
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         Unary(super::OpUnary),
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         Binary(super::OpBinary),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Closure(super::OpClosure),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpUnary {
-    #[prost(enumeration = "op_unary::Kind", required, tag = "1")]
+    #[prost(enumeration="op_unary::Kind", required, tag="1")]
     pub kind: i32,
-    #[prost(uint64, optional, tag = "2")]
+    #[prost(uint64, optional, tag="2")]
     pub ffi_name: ::core::option::Option<u64>,
 }
 /// Nested message and enum types in `OpUnary`.
@@ -253,9 +253,9 @@ pub mod op_unary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpBinary {
-    #[prost(enumeration = "op_binary::Kind", required, tag = "1")]
+    #[prost(enumeration="op_binary::Kind", required, tag="1")]
     pub kind: i32,
-    #[prost(uint64, optional, tag = "2")]
+    #[prost(uint64, optional, tag="2")]
     pub ffi_name: ::core::option::Option<u64>,
 }
 /// Nested message and enum types in `OpBinary`.
@@ -297,16 +297,16 @@ pub mod op_binary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpClosure {
-    #[prost(uint32, repeated, packed = "false", tag = "1")]
+    #[prost(uint32, repeated, packed="false", tag="1")]
     pub params: ::prost::alloc::vec::Vec<u32>,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub queries: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(enumeration = "policy::Kind", required, tag = "2")]
+    #[prost(enumeration="policy::Kind", required, tag="2")]
     pub kind: i32,
 }
 /// Nested message and enum types in `Policy`.
@@ -320,110 +320,111 @@ pub mod policy {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerPolicies {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag = "2")]
+    #[prost(uint32, optional, tag="2")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag = "5")]
+    #[prost(message, repeated, tag="5")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag = "6")]
+    #[prost(message, repeated, tag="6")]
     pub policies: ::prost::alloc::vec::Vec<Policy>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ThirdPartyBlockRequest {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub legacy_previous_key: ::core::option::Option<PublicKey>,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub legacy_public_keys: ::prost::alloc::vec::Vec<PublicKey>,
-    #[prost(bytes = "vec", required, tag = "3")]
+    #[prost(bytes="vec", required, tag="3")]
     pub previous_signature: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ThirdPartyBlockContents {
-    #[prost(bytes = "vec", required, tag = "1")]
+    #[prost(bytes="vec", required, tag="1")]
     pub payload: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub external_signature: ExternalSignature,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerSnapshot {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub limits: RunLimits,
-    #[prost(uint64, required, tag = "2")]
+    #[prost(uint64, required, tag="2")]
     pub execution_time: u64,
-    #[prost(message, required, tag = "3")]
+    #[prost(message, required, tag="3")]
     pub world: AuthorizerWorld,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunLimits {
-    #[prost(uint64, required, tag = "1")]
+    #[prost(uint64, required, tag="1")]
     pub max_facts: u64,
-    #[prost(uint64, required, tag = "2")]
+    #[prost(uint64, required, tag="2")]
     pub max_iterations: u64,
-    #[prost(uint64, required, tag = "3")]
+    #[prost(uint64, required, tag="3")]
     pub max_time: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerWorld {
-    #[prost(uint32, optional, tag = "1")]
+    #[prost(uint32, optional, tag="1")]
     pub version: ::core::option::Option<u32>,
-    #[prost(string, repeated, tag = "2")]
+    #[prost(string, repeated, tag="2")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub public_keys: ::prost::alloc::vec::Vec<PublicKey>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub blocks: ::prost::alloc::vec::Vec<SnapshotBlock>,
-    #[prost(message, required, tag = "5")]
+    #[prost(message, required, tag="5")]
     pub authorizer_block: SnapshotBlock,
-    #[prost(message, repeated, tag = "6")]
+    #[prost(message, repeated, tag="6")]
     pub authorizer_policies: ::prost::alloc::vec::Vec<Policy>,
-    #[prost(message, repeated, tag = "7")]
+    #[prost(message, repeated, tag="7")]
     pub generated_facts: ::prost::alloc::vec::Vec<GeneratedFacts>,
-    #[prost(uint64, required, tag = "8")]
+    #[prost(uint64, required, tag="8")]
     pub iterations: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Origin {
-    #[prost(oneof = "origin::Content", tags = "1, 2")]
+    #[prost(oneof="origin::Content", tags="1, 2")]
     pub content: ::core::option::Option<origin::Content>,
 }
 /// Nested message and enum types in `Origin`.
 pub mod origin {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(message, tag = "1")]
+        #[prost(message, tag="1")]
         Authorizer(super::Empty),
-        #[prost(uint32, tag = "2")]
+        #[prost(uint32, tag="2")]
         Origin(u32),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Empty {}
+pub struct Empty {
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedFacts {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub origins: ::prost::alloc::vec::Vec<Origin>,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotBlock {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string, optional, tag="1")]
     pub context: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag = "2")]
+    #[prost(uint32, optional, tag="2")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag = "5")]
+    #[prost(message, repeated, tag="5")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag = "6")]
+    #[prost(message, repeated, tag="6")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag="7")]
     pub external_key: ::core::option::Option<PublicKey>,
 }

--- a/biscuit-auth/src/format/schema.rs
+++ b/biscuit-auth/src/format/schema.rs
@@ -1,39 +1,39 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Biscuit {
-    #[prost(uint32, optional, tag="1")]
+    #[prost(uint32, optional, tag = "1")]
     pub root_key_id: ::core::option::Option<u32>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub authority: SignedBlock,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub blocks: ::prost::alloc::vec::Vec<SignedBlock>,
-    #[prost(message, required, tag="4")]
+    #[prost(message, required, tag = "4")]
     pub proof: Proof,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedBlock {
-    #[prost(bytes="vec", required, tag="1")]
+    #[prost(bytes = "vec", required, tag = "1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub next_key: PublicKey,
-    #[prost(bytes="vec", required, tag="3")]
+    #[prost(bytes = "vec", required, tag = "3")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub external_signature: ::core::option::Option<ExternalSignature>,
-    #[prost(uint32, optional, tag="5")]
+    #[prost(uint32, optional, tag = "5")]
     pub version: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExternalSignature {
-    #[prost(bytes="vec", required, tag="1")]
+    #[prost(bytes = "vec", required, tag = "1")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub public_key: PublicKey,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublicKey {
-    #[prost(enumeration="public_key::Algorithm", required, tag="1")]
+    #[prost(enumeration = "public_key::Algorithm", required, tag = "1")]
     pub algorithm: i32,
-    #[prost(bytes="vec", required, tag="2")]
+    #[prost(bytes = "vec", required, tag = "2")]
     pub key: ::prost::alloc::vec::Vec<u8>,
 }
 /// Nested message and enum types in `PublicKey`.
@@ -47,41 +47,41 @@ pub mod public_key {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
-    #[prost(oneof="proof::Content", tags="1, 2")]
+    #[prost(oneof = "proof::Content", tags = "1, 2")]
     pub content: ::core::option::Option<proof::Content>,
 }
 /// Nested message and enum types in `Proof`.
 pub mod proof {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(bytes, tag="1")]
+        #[prost(bytes, tag = "1")]
         NextSecret(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag="2")]
+        #[prost(bytes, tag = "2")]
         FinalSignature(::prost::alloc::vec::Vec<u8>),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Block {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub context: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="3")]
+    #[prost(uint32, optional, tag = "3")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
-    #[prost(message, repeated, tag="8")]
+    #[prost(message, repeated, tag = "8")]
     pub public_keys: ::prost::alloc::vec::Vec<PublicKey>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Scope {
-    #[prost(oneof="scope::Content", tags="1, 2")]
+    #[prost(oneof = "scope::Content", tags = "1, 2")]
     pub content: ::core::option::Option<scope::Content>,
 }
 /// Nested message and enum types in `Scope`.
@@ -94,33 +94,33 @@ pub mod scope {
     }
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(enumeration="ScopeType", tag="1")]
+        #[prost(enumeration = "ScopeType", tag = "1")]
         ScopeType(i32),
-        #[prost(int64, tag="2")]
+        #[prost(int64, tag = "2")]
         PublicKey(i64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fact {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub predicate: Predicate,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Rule {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub head: Predicate,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub body: ::prost::alloc::vec::Vec<Predicate>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub expressions: ::prost::alloc::vec::Vec<Expression>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Check {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub queries: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(enumeration="check::Kind", optional, tag="2")]
+    #[prost(enumeration = "check::Kind", optional, tag = "2")]
     pub kind: ::core::option::Option<i32>,
 }
 /// Nested message and enum types in `Check`.
@@ -135,108 +135,108 @@ pub mod check {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Predicate {
-    #[prost(uint64, required, tag="1")]
+    #[prost(uint64, required, tag = "1")]
     pub name: u64,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub terms: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Term {
-    #[prost(oneof="term::Content", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof = "term::Content", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub content: ::core::option::Option<term::Content>,
 }
 /// Nested message and enum types in `Term`.
 pub mod term {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(uint32, tag="1")]
+        #[prost(uint32, tag = "1")]
         Variable(u32),
-        #[prost(int64, tag="2")]
+        #[prost(int64, tag = "2")]
         Integer(i64),
-        #[prost(uint64, tag="3")]
+        #[prost(uint64, tag = "3")]
         String(u64),
-        #[prost(uint64, tag="4")]
+        #[prost(uint64, tag = "4")]
         Date(u64),
-        #[prost(bytes, tag="5")]
+        #[prost(bytes, tag = "5")]
         Bytes(::prost::alloc::vec::Vec<u8>),
-        #[prost(bool, tag="6")]
+        #[prost(bool, tag = "6")]
         Bool(bool),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         Set(super::TermSet),
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         Null(super::Empty),
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         Array(super::Array),
-        #[prost(message, tag="10")]
+        #[prost(message, tag = "10")]
         Map(super::Map),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TermSet {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub set: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Array {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub array: ::prost::alloc::vec::Vec<Term>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Map {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub entries: ::prost::alloc::vec::Vec<MapEntry>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapEntry {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub key: MapKey,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub value: Term,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapKey {
-    #[prost(oneof="map_key::Content", tags="1, 2")]
+    #[prost(oneof = "map_key::Content", tags = "1, 2")]
     pub content: ::core::option::Option<map_key::Content>,
 }
 /// Nested message and enum types in `MapKey`.
 pub mod map_key {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(int64, tag="1")]
+        #[prost(int64, tag = "1")]
         Integer(i64),
-        #[prost(uint64, tag="2")]
+        #[prost(uint64, tag = "2")]
         String(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Expression {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Op {
-    #[prost(oneof="op::Content", tags="1, 2, 3, 4")]
+    #[prost(oneof = "op::Content", tags = "1, 2, 3, 4")]
     pub content: ::core::option::Option<op::Content>,
 }
 /// Nested message and enum types in `Op`.
 pub mod op {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Value(super::Term),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Unary(super::OpUnary),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Binary(super::OpBinary),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         Closure(super::OpClosure),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpUnary {
-    #[prost(enumeration="op_unary::Kind", required, tag="1")]
+    #[prost(enumeration = "op_unary::Kind", required, tag = "1")]
     pub kind: i32,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub ffi_name: ::core::option::Option<u64>,
 }
 /// Nested message and enum types in `OpUnary`.
@@ -253,9 +253,9 @@ pub mod op_unary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpBinary {
-    #[prost(enumeration="op_binary::Kind", required, tag="1")]
+    #[prost(enumeration = "op_binary::Kind", required, tag = "1")]
     pub kind: i32,
-    #[prost(uint64, optional, tag="2")]
+    #[prost(uint64, optional, tag = "2")]
     pub ffi_name: ::core::option::Option<u64>,
 }
 /// Nested message and enum types in `OpBinary`.
@@ -297,16 +297,16 @@ pub mod op_binary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpClosure {
-    #[prost(uint32, repeated, packed="false", tag="1")]
+    #[prost(uint32, repeated, packed = "false", tag = "1")]
     pub params: ::prost::alloc::vec::Vec<u32>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub ops: ::prost::alloc::vec::Vec<Op>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub queries: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(enumeration="policy::Kind", required, tag="2")]
+    #[prost(enumeration = "policy::Kind", required, tag = "2")]
     pub kind: i32,
 }
 /// Nested message and enum types in `Policy`.
@@ -320,111 +320,110 @@ pub mod policy {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerPolicies {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="2")]
+    #[prost(uint32, optional, tag = "2")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub policies: ::prost::alloc::vec::Vec<Policy>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ThirdPartyBlockRequest {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub legacy_previous_key: ::core::option::Option<PublicKey>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub legacy_public_keys: ::prost::alloc::vec::Vec<PublicKey>,
-    #[prost(bytes="vec", required, tag="3")]
+    #[prost(bytes = "vec", required, tag = "3")]
     pub previous_signature: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ThirdPartyBlockContents {
-    #[prost(bytes="vec", required, tag="1")]
+    #[prost(bytes = "vec", required, tag = "1")]
     pub payload: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub external_signature: ExternalSignature,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerSnapshot {
-    #[prost(message, required, tag="1")]
+    #[prost(message, required, tag = "1")]
     pub limits: RunLimits,
-    #[prost(uint64, required, tag="2")]
+    #[prost(uint64, required, tag = "2")]
     pub execution_time: u64,
-    #[prost(message, required, tag="3")]
+    #[prost(message, required, tag = "3")]
     pub world: AuthorizerWorld,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunLimits {
-    #[prost(uint64, required, tag="1")]
+    #[prost(uint64, required, tag = "1")]
     pub max_facts: u64,
-    #[prost(uint64, required, tag="2")]
+    #[prost(uint64, required, tag = "2")]
     pub max_iterations: u64,
-    #[prost(uint64, required, tag="3")]
+    #[prost(uint64, required, tag = "3")]
     pub max_time: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizerWorld {
-    #[prost(uint32, optional, tag="1")]
+    #[prost(uint32, optional, tag = "1")]
     pub version: ::core::option::Option<u32>,
-    #[prost(string, repeated, tag="2")]
+    #[prost(string, repeated, tag = "2")]
     pub symbols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub public_keys: ::prost::alloc::vec::Vec<PublicKey>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub blocks: ::prost::alloc::vec::Vec<SnapshotBlock>,
-    #[prost(message, required, tag="5")]
+    #[prost(message, required, tag = "5")]
     pub authorizer_block: SnapshotBlock,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub authorizer_policies: ::prost::alloc::vec::Vec<Policy>,
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub generated_facts: ::prost::alloc::vec::Vec<GeneratedFacts>,
-    #[prost(uint64, required, tag="8")]
+    #[prost(uint64, required, tag = "8")]
     pub iterations: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Origin {
-    #[prost(oneof="origin::Content", tags="1, 2")]
+    #[prost(oneof = "origin::Content", tags = "1, 2")]
     pub content: ::core::option::Option<origin::Content>,
 }
 /// Nested message and enum types in `Origin`.
 pub mod origin {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Authorizer(super::Empty),
-        #[prost(uint32, tag="2")]
+        #[prost(uint32, tag = "2")]
         Origin(u32),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Empty {
-}
+pub struct Empty {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedFacts {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub origins: ::prost::alloc::vec::Vec<Origin>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotBlock {
-    #[prost(string, optional, tag="1")]
+    #[prost(string, optional, tag = "1")]
     pub context: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint32, optional, tag="2")]
+    #[prost(uint32, optional, tag = "2")]
     pub version: ::core::option::Option<u32>,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub facts: ::prost::alloc::vec::Vec<Fact>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub rules: ::prost::alloc::vec::Vec<Rule>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub checks: ::prost::alloc::vec::Vec<Check>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub scope: ::prost::alloc::vec::Vec<Scope>,
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub external_key: ::core::option::Option<PublicKey>,
 }

--- a/biscuit-auth/src/parser.rs
+++ b/biscuit-auth/src/parser.rs
@@ -268,17 +268,17 @@ mod tests {
         let mut syms = SymbolTable::new();
 
         let input = " -1 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = biscuit_parser::parser::expr(input).map(|(i, o)| (i, o.into()));
         assert_eq!(res, Ok((" ", Expr::Value(Term::Integer(-1)))));
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let e = builder::Expression { ops }.convert(&mut syms);
         println!("print: {}", e.print(&syms).unwrap());
 
         let input = " $0 <= 2019-12-04T09:46:41+00:00";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = biscuit_parser::parser::expr(input).map(|(i, o)| (i, o.into()));
         assert_eq!(
             res,
@@ -295,12 +295,12 @@ mod tests {
         );
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let e = builder::Expression { ops }.convert(&mut syms);
         println!("print: {}", e.print(&syms).unwrap());
 
         let input = " 1 < $test + 2 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res: Result<(&str, Expr), _> =
             biscuit_parser::parser::expr(input).map(|(i, o)| (i, o.into()));
         assert_eq!(
@@ -320,12 +320,12 @@ mod tests {
         );
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let e = builder::Expression { ops }.convert(&mut syms);
         println!("print: {}", e.print(&syms).unwrap());
 
         let input = " 2 < $test && $var2.starts_with(\"test\") && true ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = biscuit_parser::parser::expr(input).map(|(i, o)| (i, o.into()));
         assert_eq!(
             res,
@@ -358,7 +358,7 @@ mod tests {
         );
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let e = builder::Expression { ops }.convert(&mut syms);
         println!("print: {}", e.print(&syms).unwrap());
 
@@ -374,13 +374,13 @@ mod tests {
         let mut syms = SymbolTable::new();
 
         let input = " 1 + 2 * 3 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let (_, res): (_, Expr) = biscuit_parser::parser::expr(input)
             .map(|(i, o)| (i, o.into()))
             .unwrap();
 
         let ops = res.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let e = builder::Expression { ops: ops.clone() }.convert(&mut syms);
 
         let printed = e.print(&syms).unwrap();
@@ -393,7 +393,7 @@ mod tests {
                 &Default::default(),
             )
             .unwrap();
-        println!("evaluates to: {:?}", result);
+        println!("evaluates to: {result:?}");
 
         assert_eq!(
             ops,
@@ -409,13 +409,13 @@ mod tests {
         assert_eq!(result, datalog::Term::Integer(7));
 
         let input = " (1 + 2) * 3 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let (_, res): (_, Expr) = biscuit_parser::parser::expr(input)
             .map(|(i, o)| (i, o.into()))
             .unwrap();
 
         let ops = res.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let e = builder::Expression { ops: ops.clone() }.convert(&mut syms);
 
         let printed = e.print(&syms).unwrap();
@@ -428,7 +428,7 @@ mod tests {
                 &Default::default(),
             )
             .unwrap();
-        println!("evaluates to: {:?}", result);
+        println!("evaluates to: {result:?}");
 
         assert_eq!(
             ops,
@@ -477,7 +477,7 @@ mod tests {
         "#;
 
         let res = biscuit_parser::parser::parse_source(input);
-        println!("parse_source res:\n{:#?}", res);
+        println!("parse_source res:\n{res:#?}");
 
         let empty_terms: &[builder::Term] = &[];
         let empty_preds: &[builder::Predicate] = &[];
@@ -635,7 +635,7 @@ mod tests {
         "#;
 
         let res = biscuit_parser::parser::parse_block_source(input);
-        println!("parse_block_source res:\n{:#?}", res);
+        println!("parse_block_source res:\n{res:#?}");
 
         let empty_terms: &[builder::Term] = &[];
         let empty_preds: &[builder::Predicate] = &[];

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -739,7 +739,7 @@ impl std::fmt::Display for Authorizer {
             }
 
             for fact in facts {
-                writeln!(f, "{};", fact)?;
+                writeln!(f, "{fact};")?;
             }
         }
 
@@ -775,7 +775,7 @@ impl std::fmt::Display for Authorizer {
             let mut sorted_rule_list = rule_list.iter().collect::<Vec<_>>();
             sorted_rule_list.sort();
             for rule in sorted_rule_list {
-                writeln!(f, "{};", rule)?;
+                writeln!(f, "{rule};")?;
             }
         }
 
@@ -892,13 +892,13 @@ impl AuthorizerPolicies {
         proto
             .encode(&mut v)
             .map(|_| v)
-            .map_err(|e| error::Format::SerializationError(format!("serialization error: {:?}", e)))
+            .map_err(|e| error::Format::SerializationError(format!("serialization error: {e:?}")))
             .map_err(error::Token::Format)
     }
 
     pub fn deserialize(data: &[u8]) -> Result<Self, error::Token> {
         let data = crate::format::schema::AuthorizerPolicies::decode(data).map_err(|e| {
-            error::Format::DeserializationError(format!("deserialization error: {:?}", e))
+            error::Format::DeserializationError(format!("deserialization error: {e:?}"))
         })?;
 
         Ok(crate::format::convert::proto_authorizer_to_authorizer(
@@ -1213,7 +1213,7 @@ mod tests {
             .build(&biscuit2)
             .unwrap();
 
-        println!("token:\n{}", biscuit2);
+        println!("token:\n{biscuit2}");
         println!("world:\n{}", authorizer.print_world());
 
         let res = authorizer.authorize_with_limits(AuthorizerLimits {

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -174,7 +174,7 @@ impl super::Authorizer {
 
     pub fn from_raw_snapshot(input: &[u8]) -> Result<Self, error::Token> {
         let snapshot = schema::AuthorizerSnapshot::decode(input).map_err(|e| {
-            error::Format::DeserializationError(format!("deserialization error: {:?}", e))
+            error::Format::DeserializationError(format!("deserialization error: {e:?}"))
         })?;
         Self::from_snapshot(snapshot)
     }
@@ -263,7 +263,7 @@ impl super::Authorizer {
         let snapshot = self.snapshot()?;
         let mut bytes = Vec::new();
         snapshot.encode(&mut bytes).map_err(|e| {
-            error::Format::SerializationError(format!("serialization error: {:?}", e))
+            error::Format::SerializationError(format!("serialization error: {e:?}"))
         })?;
         Ok(bytes)
     }

--- a/biscuit-auth/src/token/builder/algorithm.rs
+++ b/biscuit-auth/src/token/builder/algorithm.rs
@@ -22,6 +22,7 @@ impl Algorithm {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for Algorithm {
     fn default() -> Self {
         Self::Ed25519
@@ -51,8 +52,7 @@ impl TryFrom<&str> for Algorithm {
             "ed25519" => Ok(Algorithm::Ed25519),
             "secp256r1" => Ok(Algorithm::Secp256r1),
             _ => Err(error::Format::DeserializationError(format!(
-                "deserialization error: unexpected key algorithm {}",
-                value
+                "deserialization error: unexpected key algorithm {value}"
             ))),
         }
     }

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -629,7 +629,7 @@ impl AuthorizerBuilder {
 
     pub fn from_raw_snapshot(input: &[u8]) -> Result<Self, error::Token> {
         let snapshot = schema::AuthorizerSnapshot::decode(input).map_err(|e| {
-            error::Format::DeserializationError(format!("deserialization error: {:?}", e))
+            error::Format::DeserializationError(format!("deserialization error: {e:?}"))
         })?;
         Self::from_snapshot(snapshot)
     }
@@ -689,7 +689,7 @@ impl AuthorizerBuilder {
         let snapshot = self.snapshot()?;
         let mut bytes = Vec::new();
         snapshot.encode(&mut bytes).map_err(|e| {
-            error::Format::SerializationError(format!("serialization error: {:?}", e))
+            error::Format::SerializationError(format!("serialization error: {e:?}"))
         })?;
         Ok(bytes)
     }

--- a/biscuit-auth/src/token/builder/biscuit.rs
+++ b/biscuit-auth/src/token/builder/biscuit.rs
@@ -113,13 +113,13 @@ impl BiscuitBuilder {
         let (facts, rules, checks) = self.dump();
         let mut f = String::new();
         for fact in facts {
-            let _ = writeln!(f, "{};", fact);
+            let _ = writeln!(f, "{fact};");
         }
         for rule in rules {
-            let _ = writeln!(f, "{};", rule);
+            let _ = writeln!(f, "{rule};");
         }
         for check in checks {
-            let _ = writeln!(f, "{};", check);
+            let _ = writeln!(f, "{check};");
         }
         f
     }
@@ -161,7 +161,7 @@ impl fmt::Display for BiscuitBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.root_key_id {
             None => writeln!(f, "// no root key id set")?,
-            Some(id) => writeln!(f, "// root key id: {}", id)?,
+            Some(id) => writeln!(f, "// root key id: {id}")?,
         }
         self.inner.fmt(f)
     }

--- a/biscuit-auth/src/token/builder/expression.rs
+++ b/biscuit-auth/src/token/builder/expression.rs
@@ -93,7 +93,7 @@ impl fmt::Display for Expression {
         let mut syms = default_symbol_table();
         let expr = self.convert(&mut syms);
         let s = expr.print(&syms).unwrap();
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/biscuit-auth/src/token/builder/rule.rs
+++ b/biscuit-auth/src/token/builder/rule.rs
@@ -145,7 +145,7 @@ impl Rule {
                     "rule head contains variables that are not used in predicates of the rule's body: {}",
                     head_variables
                     .iter()
-                    .map(|s| format!("${}", s))
+                    .map(|s| format!("${s}"))
                     .collect::<Vec<_>>()
                     .join(", ")
                     ))

--- a/biscuit-auth/src/token/builder/scope.rs
+++ b/biscuit-auth/src/token/builder/scope.rs
@@ -59,7 +59,7 @@ impl fmt::Display for Scope {
             Scope::Previous => write!(f, "previous"),
             Scope::PublicKey(pk) => pk.write(f),
             Scope::Parameter(s) => {
-                write!(f, "{{{}}}", s)
+                write!(f, "{{{s}}}")
             }
         }
     }

--- a/biscuit-auth/src/token/builder/term.rs
+++ b/biscuit-auth/src/token/builder/term.rs
@@ -340,9 +340,9 @@ impl AsRef<Term> for Term {
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Term::Variable(i) => write!(f, "${}", i),
-            Term::Integer(i) => write!(f, "{}", i),
-            Term::Str(s) => write!(f, "\"{}\"", s),
+            Term::Variable(i) => write!(f, "${i}"),
+            Term::Integer(i) => write!(f, "{i}"),
+            Term::Str(s) => write!(f, "\"{s}\""),
             Term::Date(d) => {
                 let date = time::OffsetDateTime::from_unix_timestamp(*d as i64)
                     .ok()
@@ -352,7 +352,7 @@ impl fmt::Display for Term {
                     })
                     .unwrap_or_else(|| "<invalid date>".to_string());
 
-                write!(f, "{}", date)
+                write!(f, "{date}")
             }
             Term::Bytes(s) => write!(f, "hex:{}", hex::encode(s)),
             Term::Bool(b) => {
@@ -371,7 +371,7 @@ impl fmt::Display for Term {
                 }
             }
             Term::Parameter(s) => {
-                write!(f, "{{{}}}", s)
+                write!(f, "{{{s}}}")
             }
             Term::Null => write!(f, "null"),
             Term::Array(a) => {
@@ -382,9 +382,9 @@ impl fmt::Display for Term {
                 let terms = m
                     .iter()
                     .map(|(key, term)| match key {
-                        MapKey::Integer(i) => format!("{i}: {}", term),
-                        MapKey::Str(s) => format!("\"{s}\": {}", term),
-                        MapKey::Parameter(s) => format!("{{{s}}}: {}", term),
+                        MapKey::Integer(i) => format!("{i}: {term}"),
+                        MapKey::Str(s) => format!("\"{s}\": {term}"),
+                        MapKey::Parameter(s) => format!("{{{s}}}: {term}"),
                     })
                     .collect::<Vec<_>>();
                 write!(f, "{{{}}}", terms.join(", "))
@@ -419,8 +419,7 @@ impl TryFrom<Term> for i64 {
         match value {
             Term::Integer(i) => Ok(i),
             _ => Err(error::Token::ConversionError(format!(
-                "expected integer, got {:?}",
-                value
+                "expected integer, got {value:?}"
             ))),
         }
     }
@@ -445,8 +444,7 @@ impl TryFrom<Term> for bool {
         match value {
             Term::Bool(b) => Ok(b),
             _ => Err(error::Token::ConversionError(format!(
-                "expected boolean, got {:?}",
-                value
+                "expected boolean, got {value:?}"
             ))),
         }
     }
@@ -484,8 +482,7 @@ impl TryFrom<Term> for String {
         match value {
             Term::Str(s) => Ok(s),
             _ => Err(error::Token::ConversionError(format!(
-                "expected string or symbol, got {:?}",
-                value
+                "expected string or symbol, got {value:?}"
             ))),
         }
     }
@@ -510,8 +507,7 @@ impl TryFrom<Term> for Vec<u8> {
         match value {
             Term::Bytes(b) => Ok(b),
             _ => Err(error::Token::ConversionError(format!(
-                "expected byte array, got {:?}",
-                value
+                "expected byte array, got {value:?}"
             ))),
         }
     }
@@ -557,8 +553,7 @@ impl TryFrom<Term> for SystemTime {
         match value {
             Term::Date(d) => Ok(UNIX_EPOCH + Duration::from_secs(d)),
             _ => Err(error::Token::ConversionError(format!(
-                "expected date, got {:?}",
-                value
+                "expected date, got {value:?}"
             ))),
         }
     }
@@ -583,8 +578,7 @@ impl<T: Ord + TryFrom<Term, Error = error::Token>> TryFrom<Term> for BTreeSet<T>
         match value {
             Term::Set(d) => d.iter().cloned().map(TryFrom::try_from).collect(),
             _ => Err(error::Token::ConversionError(format!(
-                "expected set, got {:?}",
-                value
+                "expected set, got {value:?}"
             ))),
         }
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -291,8 +291,7 @@ impl Biscuit {
 
         let authority = schema::Block::decode(&container.authority.data[..]).map_err(|e| {
             error::Token::Format(error::Format::BlockDeserializationError(format!(
-                "error deserializing block: {:?}",
-                e
+                "error deserializing block: {e:?}"
             )))
         })?;
 
@@ -389,8 +388,7 @@ impl Biscuit {
         )
         .map_err(|e| {
             error::Token::Format(error::Format::BlockDeserializationError(format!(
-                "error deserializing block: {:?}",
-                e
+                "error deserializing block: {e:?}"
             )))
         })?;
         blocks.push(deser);
@@ -468,8 +466,7 @@ impl Biscuit {
 
         let block = schema::Block::decode(&payload[..]).map_err(|e| {
             error::Token::Format(error::Format::DeserializationError(format!(
-                "deserialization error: {:?}",
-                e
+                "deserialization error: {e:?}"
             )))
         })?;
 
@@ -759,7 +756,7 @@ mod tests {
                 .build_with_rng(&root, default_symbol_table(), &mut rng)
                 .unwrap();
 
-            println!("biscuit1 (authority): {}", biscuit1);
+            println!("biscuit1 (authority): {biscuit1}");
 
             biscuit1.to_vec().unwrap()
         };
@@ -818,7 +815,7 @@ mod tests {
                 .append_with_keypair(&keypair2, block2)
                 .unwrap();
 
-            println!("biscuit2 (1 check): {}", biscuit2);
+            println!("biscuit2 (1 check): {biscuit2}");
 
             biscuit2.to_vec().unwrap()
         };
@@ -851,7 +848,7 @@ mod tests {
         //panic!();
 
         let final_token = Biscuit::from(&serialized3, root.public()).unwrap();
-        println!("final token:\n{}", final_token);
+        println!("final token:\n{final_token}");
         {
             let mut builder = AuthorizerBuilder::new();
 
@@ -869,7 +866,7 @@ mod tests {
             let mut authorizer = builder.allow_all().build(&final_token).unwrap();
 
             let res = authorizer.authorize();
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
             res.unwrap();
         }
 
@@ -892,7 +889,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res2: {:#?}", res);
+            println!("res2: {res:#?}");
             assert_eq!(res,
               Err(Token::FailedLogic(Logic::Unauthorized {
                   policy: MatchedPolicy::Allow(0),
@@ -918,7 +915,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let block2 = BlockBuilder::new()
             .check_resource_prefix("/folder1/")
@@ -942,7 +939,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
             println!("authorizer:\n{}", authorizer.print_world());
             res.unwrap();
         }
@@ -961,7 +958,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res2: {:?}", res);
+            println!("res2: {res:?}");
             assert_eq!(
                 res,
                 Err(Token::FailedLogic(Logic::Unauthorized {
@@ -987,7 +984,7 @@ mod tests {
                 .unwrap();
 
             let res = authorizer.authorize();
-            println!("res3: {:?}", res);
+            println!("res3: {res:?}");
             assert_eq!(res,
               Err(Token::FailedLogic(Logic::NoMatchingPolicy {
                   checks: vec![
@@ -1008,7 +1005,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let block2 = BlockBuilder::new()
             .check_expiration_date(SystemTime::now() + Duration::from_secs(30))
@@ -1033,12 +1030,12 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
             res.unwrap();
         }
 
         {
-            println!("biscuit2: {}", biscuit2);
+            println!("biscuit2: {biscuit2}");
             let mut authorizer = AuthorizerBuilder::new()
                 .fact("resource(\"file1\")")
                 .unwrap()
@@ -1053,7 +1050,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res3: {:?}", res);
+            println!("res3: {res:?}");
 
             // error message should be like this:
             //"authorizer check 0 failed: check if revocation_id($0), $0 not in [2, 1234, 1, 5, 0]"
@@ -1074,7 +1071,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let block2 = BlockBuilder::new()
             .check_resource_prefix("/folder1/")
@@ -1100,7 +1097,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
             res.unwrap();
         }
 
@@ -1123,7 +1120,7 @@ mod tests {
                 .unwrap();
 
             let res = authorizer.authorize();
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
             res.unwrap();
         }
     }
@@ -1144,7 +1141,7 @@ mod tests {
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
-        println!("{}", biscuit1);
+        println!("{biscuit1}");
 
         let mut authorizer = AuthorizerBuilder::new()
             .check(rule(
@@ -1161,7 +1158,7 @@ mod tests {
             max_time: Duration::from_secs(10),
             ..Default::default()
         });
-        println!("res: {:?}", res);
+        println!("res: {res:?}");
         assert_eq!(
             res,
             Err(Token::FailedLogic(Logic::NoMatchingPolicy {
@@ -1186,7 +1183,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let block2 = BlockBuilder::new()
             .check_expiration_date(SystemTime::now() + Duration::from_secs(30))
@@ -1204,7 +1201,7 @@ mod tests {
         let keypair3 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
         let biscuit3 = biscuit2.append_with_keypair(&keypair3, block3).unwrap();
         {
-            println!("biscuit3: {}", biscuit3);
+            println!("biscuit3: {biscuit3}");
 
             let mut authorizer = AuthorizerBuilder::new()
                 .fact("resource(\"file1\")")
@@ -1222,7 +1219,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("authorization result: {:?}", authorization_res);
+            println!("authorization result: {authorization_res:?}");
 
             println!("world:\n{}", authorizer.print_world());
             let res2: Result<Vec<builder::Fact>, crate::error::Token> = authorizer
@@ -1234,7 +1231,7 @@ mod tests {
                     },
                 );
 
-            println!("res2: {:?}", res2);
+            println!("res2: {res2:?}");
             let mut res2 = res2
                 .unwrap()
                 .iter()
@@ -1252,7 +1249,7 @@ mod tests {
 
             let res1: Result<Vec<builder::Fact>, crate::error::Token> =
                 other_authorizer.query("key_verif($id) <- key($id)");
-            println!("res1: {:?}", res1);
+            println!("res1: {res1:?}");
             assert_eq!(
                 res1.unwrap()
                     .into_iter()
@@ -1277,7 +1274,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         // new check: can only have read access1
         let block2 = BlockBuilder::new()
@@ -1287,7 +1284,7 @@ mod tests {
         let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
 
-        println!("biscuit2: {}", biscuit2);
+        println!("biscuit2: {biscuit2}");
 
         //println!("generated biscuit token 2: {} bytes\n{}", serialized2.len(), serialized2.to_hex(16));
         {
@@ -1307,7 +1304,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
 
             assert_eq!(
                 res,
@@ -1378,7 +1375,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let block2 = BlockBuilder::new()
             .rule("has_bytes($0) <- bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
@@ -1401,7 +1398,7 @@ mod tests {
             max_time: Duration::from_secs(10),
             ..Default::default()
         });
-        println!("res1: {:?}", res);
+        println!("res1: {res:?}");
         res.unwrap();
 
         let res: Vec<(Vec<u8>,)> = authorizer
@@ -1413,7 +1410,7 @@ mod tests {
                 },
             )
             .unwrap();
-        println!("query result: {:x?}", res);
+        println!("query result: {res:x?}");
         println!("query result: {:?}", res[0]);
     }
 
@@ -1435,7 +1432,7 @@ mod tests {
                 .build_with_rng(&root, default_symbol_table(), &mut rng)
                 .unwrap();
 
-            println!("biscuit1 (authority): {}", biscuit1);
+            println!("biscuit1 (authority): {biscuit1}");
 
             biscuit1.to_vec().unwrap()
         };
@@ -1467,7 +1464,7 @@ mod tests {
                 .append_with_keypair(&keypair2, block2)
                 .unwrap();
 
-            println!("biscuit2 (1 check): {}", biscuit2);
+            println!("biscuit2 (1 check): {biscuit2}");
 
             biscuit2.to_vec().unwrap()
         };
@@ -1476,7 +1473,7 @@ mod tests {
         println!("generated biscuit token 2: {} bytes", serialized2.len());
 
         let final_token = Biscuit::from(&serialized2, root.public()).unwrap();
-        println!("final token:\n{}", final_token);
+        println!("final token:\n{final_token}");
 
         let mut authorizer = AuthorizerBuilder::new()
             .fact("resource(\"/folder2/file1\")")
@@ -1493,7 +1490,7 @@ mod tests {
             max_time: Duration::from_secs(1),
             ..Default::default()
         });
-        println!("res1: {:?}", res);
+        println!("res1: {res:?}");
         println!("authorizer:\n{}", authorizer.print_world());
 
         assert!(res.is_err());
@@ -1510,7 +1507,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let biscuit2 = Biscuit::builder()
             .check("check all fact($v), $v < 1")
@@ -1518,7 +1515,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit2 (authority): {}", biscuit2);
+        println!("biscuit2 (authority): {biscuit2}");
 
         {
             let mut authorizer = AuthorizerBuilder::new()
@@ -1535,7 +1532,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res1: {:?}", res);
+            println!("res1: {res:?}");
             res.unwrap();
         }
 
@@ -1554,7 +1551,7 @@ mod tests {
                 max_time: Duration::from_secs(10),
                 ..Default::default()
             });
-            println!("res2: {:?}", res);
+            println!("res2: {res:?}");
 
             assert_eq!(
                 res,
@@ -1637,7 +1634,7 @@ mod tests {
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
-        println!("biscuit1 (authority): {}", biscuit1);
+        println!("biscuit1 (authority): {biscuit1}");
 
         let serialized = biscuit1.to_vec().unwrap();
 

--- a/biscuit-auth/src/token/third_party.rs
+++ b/biscuit-auth/src/token/third_party.rs
@@ -53,8 +53,7 @@ impl ThirdPartyRequest {
 
         request.encode(&mut v).map(|_| v).map_err(|e| {
             error::Token::Format(error::Format::SerializationError(format!(
-                "serialization error: {:?}",
-                e
+                "serialization error: {e:?}"
             )))
         })
     }
@@ -65,7 +64,7 @@ impl ThirdPartyRequest {
 
     pub fn deserialize(slice: &[u8]) -> Result<Self, error::Token> {
         let data = schema::ThirdPartyBlockRequest::decode(slice).map_err(|e| {
-            error::Format::DeserializationError(format!("deserialization error: {:?}", e))
+            error::Format::DeserializationError(format!("deserialization error: {e:?}"))
         })?;
 
         if !data.legacy_public_keys.is_empty() {
@@ -107,7 +106,7 @@ impl ThirdPartyRequest {
         token_block_to_proto_block(&block)
             .encode(&mut payload)
             .map_err(|e| {
-                error::Format::SerializationError(format!("serialization error: {:?}", e))
+                error::Format::SerializationError(format!("serialization error: {e:?}"))
             })?;
 
         let signed_payload = generate_external_signature_payload_v1(
@@ -144,8 +143,7 @@ impl ThirdPartyBlock {
         let mut buffer = vec![];
         self.0.encode(&mut buffer).map(|_| buffer).map_err(|e| {
             error::Token::Format(error::Format::SerializationError(format!(
-                "serialization error: {:?}",
-                e
+                "serialization error: {e:?}"
             )))
         })
     }

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -182,8 +182,7 @@ impl UnverifiedBiscuit {
         )
         .map_err(|e| {
             error::Token::Format(error::Format::BlockDeserializationError(format!(
-                "error deserializing block: {:?}",
-                e
+                "error deserializing block: {e:?}"
             )))
         })?;
         blocks.push(deser);
@@ -315,7 +314,7 @@ impl UnverifiedBiscuit {
             payload,
             external_signature,
         } = schema::ThirdPartyBlockContents::decode(slice).map_err(|e| {
-            error::Format::DeserializationError(format!("deserialization error: {:?}", e))
+            error::Format::DeserializationError(format!("deserialization error: {e:?}"))
         })?;
 
         let algorithm =
@@ -328,8 +327,7 @@ impl UnverifiedBiscuit {
             PublicKey::from_bytes(&external_signature.public_key.key, algorithm.into()).map_err(
                 |e| {
                     error::Format::BlockSignatureDeserializationError(format!(
-                        "block external public key deserialization error: {:?}",
-                        e
+                        "block external public key deserialization error: {e:?}"
                     ))
                 },
             )?;
@@ -338,8 +336,7 @@ impl UnverifiedBiscuit {
 
         let block = schema::Block::decode(&payload[..]).map_err(|e| {
             error::Token::Format(error::Format::DeserializationError(format!(
-                "deserialization error: {:?}",
-                e
+                "deserialization error: {e:?}"
             )))
         })?;
 

--- a/biscuit-auth/tests/rights.rs
+++ b/biscuit-auth/tests/rights.rs
@@ -33,7 +33,7 @@ fn main() {
         .unwrap()
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
-    println!("{}", biscuit1);
+    println!("{biscuit1}");
 
     let mut v = AuthorizerBuilder::new()
         .check(rule(
@@ -52,6 +52,6 @@ fn main() {
     //v.add_operation("write");
 
     let res = v.authorize();
-    println!("{:#?}", res);
+    println!("{res:#?}");
     panic!()
 }

--- a/biscuit-capi/src/lib.rs
+++ b/biscuit-capi/src/lib.rs
@@ -22,7 +22,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::InvalidArgument => write!(f, "invalid argument"),
-            Error::Biscuit(e) => write!(f, "{}", e),
+            Error::Biscuit(e) => write!(f, "{e}"),
         }
     }
 }
@@ -313,6 +313,7 @@ pub enum SignatureAlgorithm {
     Secp256r1,
 }
 
+#[allow(clippy::extra_unused_lifetimes)]
 #[no_mangle]
 pub unsafe extern "C" fn key_pair_new<'a>(
     seed_ptr: *const u8,
@@ -346,7 +347,7 @@ pub unsafe extern "C" fn key_pair_public(kp: Option<&KeyPair>) -> Option<Box<Pub
     }
     let kp = kp?;
 
-    Some(Box::new(PublicKey((*kp).0.public())))
+    Some(Box::new(PublicKey(kp.0.public())))
 }
 
 /// expects a 32 byte buffer
@@ -712,7 +713,7 @@ pub unsafe extern "C" fn biscuit_builder_build(
     seed.copy_from_slice(slice);
 
     let mut rng: StdRng = SeedableRng::from_seed(seed);
-    (*builder)
+    builder
         .0
         .clone()
         .expect("builder is none")
@@ -722,14 +723,15 @@ pub unsafe extern "C" fn biscuit_builder_build(
         .ok()
 }
 
+#[allow(clippy::extra_unused_lifetimes)]
 #[no_mangle]
 pub unsafe extern "C" fn biscuit_builder_free<'a>(_builder: Option<Box<BiscuitBuilder>>) {}
 
 #[no_mangle]
-pub unsafe extern "C" fn biscuit_from<'a>(
+pub unsafe extern "C" fn biscuit_from(
     biscuit_ptr: *const u8,
     biscuit_len: usize,
-    root: Option<&'a PublicKey>,
+    root: Option<&PublicKey>,
 ) -> Option<Box<Biscuit>> {
     let biscuit = std::slice::from_raw_parts(biscuit_ptr, biscuit_len);
     if root.is_none() {
@@ -756,7 +758,7 @@ pub unsafe extern "C" fn biscuit_serialized_size(biscuit: Option<&Biscuit>) -> u
         Ok(sz) => sz,
         Err(e) => {
             update_last_error(Error::Biscuit(e));
-            return 0;
+            0
         }
     }
 }
@@ -774,7 +776,7 @@ pub unsafe extern "C" fn biscuit_sealed_size(biscuit: Option<&Biscuit>) -> usize
         Ok(sz) => sz,
         Err(e) => {
             update_last_error(Error::Biscuit(e));
-            return 0;
+            0
         }
     }
 }
@@ -791,7 +793,7 @@ pub unsafe extern "C" fn biscuit_serialize(
 
     let biscuit = biscuit.unwrap();
 
-    match (*biscuit).0.to_vec() {
+    match biscuit.0.to_vec() {
         Ok(v) => {
             let size = match biscuit.0.serialized_size() {
                 Ok(sz) => sz,
@@ -825,7 +827,7 @@ pub unsafe extern "C" fn biscuit_serialize_sealed(
 
     let biscuit = biscuit.unwrap();
 
-    match (*biscuit).0.seal() {
+    match biscuit.0.seal() {
         Ok(b) => match b.to_vec() {
             Ok(v) => {
                 let size = match biscuit.0.serialized_size() {
@@ -971,15 +973,13 @@ pub unsafe extern "C" fn biscuit_append_block(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn biscuit_authorizer<'a>(
-    biscuit: Option<&'a Biscuit>,
-) -> Option<Box<Authorizer>> {
+pub unsafe extern "C" fn biscuit_authorizer(biscuit: Option<&Biscuit>) -> Option<Box<Authorizer>> {
     if biscuit.is_none() {
         update_last_error(Error::InvalidArgument);
     }
     let biscuit = biscuit?;
 
-    (*biscuit).0.authorizer().map(Authorizer).map(Box::new).ok()
+    biscuit.0.authorizer().map(Authorizer).map(Box::new).ok()
 }
 
 #[no_mangle]
@@ -1247,7 +1247,6 @@ pub unsafe extern "C" fn authorizer_builder_build(
     builder
         .0
         .clone()
-        .take()
         .unwrap()
         .build(&token.0)
         .map(Authorizer)
@@ -1269,7 +1268,6 @@ pub unsafe extern "C" fn authorizer_builder_build_unauthenticated(
     builder
         .0
         .clone()
-        .take()
         .unwrap()
         .build_unauthenticated()
         .map(Authorizer)
@@ -1309,7 +1307,7 @@ pub unsafe extern "C" fn authorizer_print(authorizer: Option<&mut Authorizer>) -
         Ok(s) => s.into_raw(),
         Err(_) => {
             update_last_error(Error::InvalidArgument);
-            return std::ptr::null_mut();
+            std::ptr::null_mut()
         }
     }
 }
@@ -1319,7 +1317,7 @@ pub unsafe extern "C" fn authorizer_free(_authorizer: Option<Box<Authorizer>>) {
 
 #[no_mangle]
 pub unsafe extern "C" fn string_free(ptr: *mut c_char) {
-    if ptr != std::ptr::null_mut() {
+    if ptr.is_null() {
         drop(CString::from_raw(ptr));
     }
 }
@@ -1336,7 +1334,7 @@ pub unsafe extern "C" fn biscuit_print(biscuit: Option<&Biscuit>) -> *const c_ch
         Ok(s) => s.into_raw(),
         Err(_) => {
             update_last_error(Error::InvalidArgument);
-            return std::ptr::null();
+            std::ptr::null()
         }
     }
 }

--- a/biscuit-parser/src/builder.rs
+++ b/biscuit-parser/src/builder.rs
@@ -501,7 +501,7 @@ impl Rule {
                     "the rule contains variables that are not bound by predicates in the rule's body: {}",
                     free_variables
                     .iter()
-                    .map(|s| format!("${}", s))
+                    .map(|s| format!("${s}"))
                     .collect::<Vec<_>>()
                     .join(", ")
                     ))

--- a/biscuit-parser/src/parser.rs
+++ b/biscuit-parser/src/parser.rs
@@ -5,6 +5,7 @@
 
 // This warning makes all parser signatures extremely verbose
 #![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::type_complexity)]
 use crate::builder::{self, CheckKind, PublicKey};
 use nom::{
     branch::alt,
@@ -31,7 +32,7 @@ pub fn fact(i: &str) -> IResult<&str, builder::Fact, Error> {
 
     let (i, _) = error(
         preceded(space0, eof),
-        |input| format!("unexpected trailing data after fact: '{}'", input),
+        |input| format!("unexpected trailing data after fact: '{input}'"),
         " ,\n",
     )(i)?;
 
@@ -64,8 +65,7 @@ pub fn check(i: &str) -> IResult<&str, builder::Check, Error> {
         |input| {
             match input.chars().next() {
             Some(')') => "unexpected parens".to_string(),
-            _ => format!("expected either the next term after ',' or the next check variant after 'or', but got '{}'",
-                     input)
+            _ => format!("expected either the next term after ',' or the next check variant after 'or', but got '{input}'")
         }
         },
         " ,\n",
@@ -96,8 +96,7 @@ pub fn policy(i: &str) -> IResult<&str, builder::Policy, Error> {
         |input| {
             match input.chars().next() {
             Some(')') => "unexpected parens".to_string(),
-            _ => format!("expected either the next term after ',' or the next policy variant after 'or', but got '{}'",
-                     input)
+            _ => format!("expected either the next term after ',' or the next policy variant after 'or', but got '{input}'")
         }
         },
         " ,\n",
@@ -174,10 +173,7 @@ pub fn rule(i: &str) -> IResult<&str, builder::Rule, Error> {
         preceded(space0, eof),
         |input| match input.chars().next() {
             Some(')') => "unexpected parens".to_string(),
-            _ => format!(
-                "expected the next term or expression after ',', but got '{}'",
-                input
-            ),
+            _ => format!("expected the next term or expression after ',', but got '{input}'"),
         },
         " ,\n",
     )(i)?;
@@ -1036,12 +1032,12 @@ pub fn parse_source(mut i: &str) -> Result<SourceResult, Vec<Error>> {
             }
             Err(nom::Err::Incomplete(_)) => panic!(),
             Err(nom::Err::Error(mut e)) => {
-                if let Some(index) = e.input.find(|c| c == ';') {
+                if let Some(index) = e.input.find(';') {
                     e.input = &(e.input)[..index];
                 }
 
                 let offset = i.offset(e.input);
-                if let Some(index) = &i[offset..].find(|c| c == ';') {
+                if let Some(index) = &i[offset..].find(';') {
                     i = &i[offset + index + 1..];
                 } else {
                     i = &i[i.len()..];
@@ -1050,12 +1046,12 @@ pub fn parse_source(mut i: &str) -> Result<SourceResult, Vec<Error>> {
                 errors.push(e);
             }
             Err(nom::Err::Failure(mut e)) => {
-                if let Some(index) = e.input.find(|c| c == ';') {
+                if let Some(index) = e.input.find(';') {
                     e.input = &(e.input)[..index];
                 }
 
                 let offset = i.offset(e.input);
-                if let Some(index) = &i[offset..].find(|c| c == ';') {
+                if let Some(index) = &i[offset..].find(';') {
                     i = &i[offset + index + 1..];
                 } else {
                     i = &i[i.len()..];
@@ -1080,12 +1076,12 @@ pub fn parse_block_source(mut i: &str) -> Result<SourceResult, Vec<Error>> {
         }
         Err(nom::Err::Incomplete(_)) => panic!(),
         Err(nom::Err::Error(mut e)) => {
-            if let Some(index) = e.input.find(|c| c == ';') {
+            if let Some(index) = e.input.find(';') {
                 e.input = &(e.input)[..index];
             }
 
             let offset = i.offset(e.input);
-            if let Some(index) = &i[offset..].find(|c| c == ';') {
+            if let Some(index) = &i[offset..].find(';') {
                 i = &i[offset + index + 1..];
             } else {
                 i = &i[i.len()..];
@@ -1094,12 +1090,12 @@ pub fn parse_block_source(mut i: &str) -> Result<SourceResult, Vec<Error>> {
             errors.push(e);
         }
         Err(nom::Err::Failure(mut e)) => {
-            if let Some(index) = e.input.find(|c| c == ';') {
+            if let Some(index) = e.input.find(';') {
                 e.input = &(e.input)[..index];
             }
 
             let offset = i.offset(e.input);
-            if let Some(index) = &i[offset..].find(|c| c == ';') {
+            if let Some(index) = &i[offset..].find(';') {
                 i = &i[offset + index + 1..];
             } else {
                 i = &i[i.len()..];
@@ -1148,12 +1144,12 @@ pub fn parse_block_source(mut i: &str) -> Result<SourceResult, Vec<Error>> {
             }
             Err(nom::Err::Incomplete(_)) => panic!(),
             Err(nom::Err::Error(mut e)) => {
-                if let Some(index) = e.input.find(|c| c == ';') {
+                if let Some(index) = e.input.find(';') {
                     e.input = &(e.input)[..index];
                 }
 
                 let offset = i.offset(e.input);
-                if let Some(index) = &i[offset..].find(|c| c == ';') {
+                if let Some(index) = &i[offset..].find(';') {
                     i = &i[offset + index + 1..];
                 } else {
                     i = &i[i.len()..];
@@ -1162,12 +1158,12 @@ pub fn parse_block_source(mut i: &str) -> Result<SourceResult, Vec<Error>> {
                 errors.push(e);
             }
             Err(nom::Err::Failure(mut e)) => {
-                if let Some(index) = e.input.find(|c| c == ';') {
+                if let Some(index) = e.input.find(';') {
                     e.input = &(e.input)[..index];
                 }
 
                 let offset = i.offset(e.input);
-                if let Some(index) = &i[offset..].find(|c| c == ';') {
+                if let Some(index) = &i[offset..].find(';') {
                     i = &i[offset + index + 1..];
                 } else {
                     i = &i[i.len()..];
@@ -2098,15 +2094,15 @@ mod tests {
         use std::time::{Duration, SystemTime};
 
         let input = " -1 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = super::expr(input);
         assert_eq!(res, Ok((" ", Expr::Value(Term::Integer(-1)))));
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
 
         let input = " $0 <= 2019-12-04T09:46:41+00:00";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = super::expr(input);
         assert_eq!(
             res,
@@ -2123,9 +2119,9 @@ mod tests {
         );
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
         let input = " 1 < $test + 2 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = super::expr(input);
         assert_eq!(
             res,
@@ -2144,10 +2140,10 @@ mod tests {
         );
 
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
 
         let input = " 2 < $test && $var2.starts_with(\"test\") && true ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let res = super::expr(input);
         assert_eq!(
             res,
@@ -2179,7 +2175,7 @@ mod tests {
             ))
         );
         let ops = res.unwrap().1.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
     }
 
     #[test]
@@ -2187,11 +2183,11 @@ mod tests {
         use builder::{int, Binary, Op, Unary};
 
         let input = " 1 + 2 * 3 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let (_, res) = super::expr(input).unwrap();
 
         let ops = res.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
 
         assert_eq!(
             ops,
@@ -2205,11 +2201,11 @@ mod tests {
         );
 
         let input = " (1 + 2) * 3 ";
-        println!("parsing: {}", input);
+        println!("parsing: {input}");
         let (_, res) = super::expr(input).unwrap();
 
         let ops = res.opcodes();
-        println!("ops: {:#?}", ops);
+        println!("ops: {ops:#?}");
 
         assert_eq!(
             ops,
@@ -2256,7 +2252,7 @@ mod tests {
         "#;
 
         let res = super::parse_source(input);
-        println!("parse_source res:\n{:#?}", res);
+        println!("parse_source res:\n{res:#?}");
 
         let empty_terms: &[builder::Term] = &[];
         let empty_preds: &[builder::Predicate] = &[];
@@ -2402,7 +2398,7 @@ mod tests {
         "#;
 
         let res = super::parse_block_source(input);
-        println!("parse_block_source res:\n{:#?}", res);
+        println!("parse_block_source res:\n{res:#?}");
 
         let empty_terms: &[builder::Term] = &[];
         let empty_preds: &[builder::Predicate] = &[];


### PR DESCRIPTION
This fixes issues identified by clippy - the most common was taking a reference to something that was already a reference.

A few warnings are supressed rather than fixed, mostly because fixing them could be a breaking change.

Also runs cargo fmt over the project.