### PR TITLE
[BREAKING] Fix TrustedOrigins default issue

### DIFF
--- a/biscuit-auth/CHANGELOG.md
+++ b/biscuit-auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+# `7.0.0`
+
+- `TrustedOrigin`'s `Default` implementation changed to match its inherent `default` function (#327)
+
 # `6.0.0`
 
 - support for `pem` / `der` private and public keys (#212 and #265)

--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -83,15 +83,21 @@ impl Display for Origin {
 }
 
 /// This represents the sets of origins trusted by a rule
-#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TrustedOrigins(Origin);
 
-impl TrustedOrigins {
-    pub fn default() -> TrustedOrigins {
+impl Default for TrustedOrigins {
+    fn default() -> TrustedOrigins {
         let mut origins = Origin::default();
         origins.insert(usize::MAX);
         origins.insert(0);
         TrustedOrigins(origins)
+    }
+}
+
+impl TrustedOrigins {
+    pub fn default() -> TrustedOrigins {
+        <TrustedOrigins as Default>::default()
     }
 
     pub fn from_scopes(


### PR DESCRIPTION
TrustedOrigins implements an inherent constructor called default and also has a derived implementation of Default. **These two constructors have different behavior.**

This means that `TrustedOrigins::default()` and `<TrustedOrigins as Default>::default()` construct different `TrustedOrigins` types. This is surprising.

This PR changes the behavior of the Default trait constructor to match the behavior of the inherent constructor.