### PR TITLE
Fix wasm32 build without the wasm feature

### DIFF
--- a/biscuit-auth/src/time.rs
+++ b/biscuit-auth/src/time.rs
@@ -14,11 +14,11 @@ use wasm_bindgen::prelude::*;
 
 pub use std::time::*;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant(std::time::Instant);
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm")))]
 #[allow(dead_code)]
 impl Instant {
     pub fn now() -> Self {
@@ -48,11 +48,11 @@ extern "C" {
     fn performance_now() -> f64;
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant(u64);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 impl Instant {
     pub fn now() -> Self {
         Self((performance_now() * 1000.0) as u64)


### PR DESCRIPTION
`biscuit-auth` fails to compile for `wasm32` targets unless the `wasm`
feature is enabled. Building for `wasm32-wasip1` (or
`wasm32-unknown-unknown` without the feature) fails with:

```
error[E0425]: cannot find function `performance_now` in this scope
error[E0599]: no method named `try_into` found for type `u128`
```

The cause is an inconsistent set of `cfg` predicates in
`biscuit-auth/src/time.rs`. The custom `Instant(u64)` struct and its
impl are gated on `target_arch = "wasm32"` alone, while the
`performance_now` extern and the `TryInto` import they depend on are
additionally gated on the `wasm` feature. A `wasm32` build without
`wasm` therefore selects the browser `Instant` but not the code it
needs.

`performance_now` is `performance.now()` bound through wasm-bindgen — a
browser API — so the JS-backed `Instant` only makes sense under the
`wasm` feature. Every other `wasm32` target, notably WASI (which has a
real monotonic clock), can use the existing `std::time::Instant`
wrapper. This change gates the JS `Instant` on
`all(target_arch = "wasm32", feature = "wasm")` and lets all other
targets fall through to the `std` implementation. Only the `cfg`
predicates move; no runtime behavior changes for existing
configurations, and there is no effect on the token format or datalog
semantics.

One judgment call worth surfacing: `wasm32-unknown-unknown` without the
`wasm` feature now compiles and relies on `std::time::Instant`, which
panics at runtime if no clock is available. That configuration
previously failed to compile, so this is not a regression, and browser
builds should keep enabling `wasm` — but if you would rather keep that
target a hard compile error, I am happy to gate it that way instead.

Verified with `cargo build -p biscuit-auth --target wasm32-wasip1`, and
by running a full keygen/mint/attenuate/authorize cycle under a WASI
host (wazero).
